### PR TITLE
feat: reverse-proxy PostHog through /ingest

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,18 @@ import { unifiedConditional } from 'unified-conditional'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx']
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // PostHog reverse-proxy: route /ingest/* through the site origin so ad
+  // blockers (uBlock, Brave shields, etc.) don't drop analytics requests.
+  // See: https://posthog.com/docs/advanced/proxy/nextjs
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      { source: '/ingest/static/:path*', destination: 'https://us-assets.i.posthog.com/static/:path*' },
+      { source: '/ingest/:path*', destination: 'https://us.i.posthog.com/:path*' },
+      { source: '/ingest/flags', destination: 'https://us.i.posthog.com/flags' },
+    ]
+  },
 }
 
 function remarkMDXLayout(source, metaName) {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,7 +5,11 @@ import { PostHogProvider as Provider } from 'posthog-js/react'
 
 if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    // Route capture through /ingest (proxied by Next.js rewrites in next.config.mjs)
+    // so ad blockers don't drop the requests. ui_host keeps PostHog dashboard
+    // links (toolbar, etc.) pointing at the real PostHog UI.
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: false,
   })


### PR DESCRIPTION
## Summary

Adds Next.js rewrites so the PostHog SDK hits same-origin \`/ingest/*\` paths instead of \`us.i.posthog.com\` directly. Recovers the 5–15% of traffic that ad blockers (uBlock, Brave shields, etc.) would otherwise drop on requests to the well-known PostHog hostname.

## Changes

- **\`next.config.mjs\`** — adds \`rewrites()\` mapping \`/ingest/static/*\` → \`us-assets.i.posthog.com\`, \`/ingest/:path*\` → \`us.i.posthog.com\`, plus an explicit \`/ingest/flags\` rule. Also \`skipTrailingSlashRedirect: true\` so Next doesn't 308 the proxied paths.
- **\`src/app/providers.tsx\`** — \`posthog.init\` now uses \`api_host: '/ingest'\` and \`ui_host: 'https://us.posthog.com'\`. \`NEXT_PUBLIC_POSTHOG_HOST\` is no longer read.

## Caveat

PostHog docs warn that some platforms strip headers during rewrites and break the proxy. \`@cloudflare/next-on-pages\` compiles to Workers, which should pass headers cleanly — but worth verifying against the CF preview URL before trusting production.

## Test plan

- [x] \`npm run build\` — clean, all 11 routes still static, first-load JS unchanged (~164kB on /)
- [ ] After deploy: curl \`https://<preview-url>/ingest/decide\` and confirm valid JSON response (proxy works)
- [ ] After deploy: open the live site with Network tab → confirm \`$pageview\` POST goes to \`/ingest/e/\` and returns 200
- [ ] After deploy: enable uBlock Origin → reload → \`$pageview\` still fires