### PR TITLE
fix: inline PostHog public key, drop env-var dependency

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,18 @@ import { unifiedConditional } from 'unified-conditional'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx']
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  // PostHog reverse-proxy: route /ingest/* through the site origin so ad
+  // blockers (uBlock, Brave shields, etc.) don't drop analytics requests.
+  // See: https://posthog.com/docs/advanced/proxy/nextjs
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      { source: '/ingest/static/:path*', destination: 'https://us-assets.i.posthog.com/static/:path*' },
+      { source: '/ingest/:path*', destination: 'https://us.i.posthog.com/:path*' },
+      { source: '/ingest/flags', destination: 'https://us.i.posthog.com/flags' },
+    ]
+  },
 }
 
 function remarkMDXLayout(source, metaName) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,7 +22,6 @@ const nextConfig = {
     return [
       { source: '/ingest/static/:path*', destination: 'https://us-assets.i.posthog.com/static/:path*' },
       { source: '/ingest/:path*', destination: 'https://us.i.posthog.com/:path*' },
-      { source: '/ingest/flags', destination: 'https://us.i.posthog.com/flags' },
     ]
   },
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,7 +5,11 @@ import { PostHogProvider as Provider } from 'posthog-js/react'
 
 if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    // Route capture through /ingest (proxied by Next.js rewrites in next.config.mjs)
+    // so ad blockers don't drop the requests. ui_host keeps PostHog dashboard
+    // links (toolbar, etc.) pointing at the real PostHog UI.
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: false,
   })

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,8 +3,16 @@
 import posthog from 'posthog-js'
 import { PostHogProvider as Provider } from 'posthog-js/react'
 
-if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+// Public PostHog project key (alexsalerno.dev, id 421445). `phc_` keys are
+// publishable and safe to ship to the browser — they can only write events.
+// Hardcoded instead of read from process.env because Cloudflare Pages' project
+// env vars don't reliably flow through next-on-pages builds (the build sees
+// NEXT_PUBLIC_POSTHOG_KEY as undefined even when configured), which silently
+// broke ingestion in production.
+const POSTHOG_KEY = 'phc_o3589uL92sVBKKiKom9pxff8aSNtYNxCPN39i8A9Xwkd'
+
+if (typeof window !== 'undefined') {
+  posthog.init(POSTHOG_KEY, {
     // Route capture through /ingest (proxied by Next.js rewrites in next.config.mjs)
     // so ad blockers don't drop the requests. ui_host keeps PostHog dashboard
     // links (toolbar, etc.) pointing at the real PostHog UI.


### PR DESCRIPTION
## Why

Zero events have been captured by the alexsalerno.dev PostHog project (id 421445) since the snippet was added in #104. The bundled JS calls `posthog.init` only when `process.env.NEXT_PUBLIC_POSTHOG_KEY` is truthy — but in production the shipped bundle contains the literal `n.env.NEXT_PUBLIC_POSTHOG_KEY` and not an inlined value, so the guard never fires.

Root cause: Cloudflare Pages' project-level env vars don't reliably flow through `next-on-pages` builds. I verified by:
1. Confirming the project key was set correctly on the **preview** deployment config (PR previews would work) but not on **production**
2. Patching the production env vars via the CF API — patch persisted in the project config
3. Triggering a fresh production deployment — bundle was rebuilt but still contained the literal `n.env.NEXT_PUBLIC_POSTHOG_KEY`, confirming the build environment isn't picking them up

## Fix

Hardcode the public `phc_` project key. PostHog `phc_…` keys are publishable and write-only — same safety profile as a Google Analytics tracking ID, safe to commit. Uses the same pattern recently adopted in `uppy-game`.

## Test plan

- [ ] After merge + production deploy, visit https://alexsalerno.dev/
- [ ] Network tab shows requests to `/ingest/e/?…` returning 200
- [ ] PostHog → alexsalerno.dev project → Live events shows `$pageview` within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)