### PR TITLE
feat: replace Projects Tracker button with quick-link row

### DIFF
--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -23,7 +23,7 @@ function QuickLinks({ projects }: { projects: Project[] }) {
         <a
           key={p.title}
           href={`#${projectSlug(p)}`}
-          className="inline-flex items-center rounded-full border border-neutral-300 px-4 py-1.5 text-sm font-medium text-neutral-950 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950"
+          className="inline-flex items-center rounded-full border border-neutral-300 px-4 py-1.5 text-sm font-medium text-neutral-950 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950"
         >
           {p.title}
         </a>
@@ -102,11 +102,6 @@ function ProjectsList({ projects }: { projects: Project[] }) {
       ))}
     </div>
   )
-}
-
-export async function Projects() {
-  const projects = (await loadProjects()).sort((a, b) => a.order - b.order)
-  return <ProjectsList projects={projects} />
 }
 
 export default async function ProjectSection() {

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -8,6 +8,30 @@ import React from 'react'
 import { QuoteBanner } from '../blocks/QuoteBanner'
 import Section from '../layout/Section'
 
+// Stable per-project slug derived from the project's href (/projects/<slug>).
+// Used both as the anchor target on the section card and as the link href in
+// the quick-links row, so clicking a chip scrolls down to the project.
+function projectSlug(project: Project): string {
+  return project.href.replace(/^\/projects\//, '').replace(/\/$/, '')
+}
+
+function QuickLinks({ projects }: { projects: Project[] }) {
+  if (projects.length === 0) return null
+  return (
+    <div className="mt-6 flex flex-wrap gap-2">
+      {projects.map((p) => (
+        <a
+          key={p.title}
+          href={`#${projectSlug(p)}`}
+          className="inline-flex items-center rounded-full border border-neutral-300 px-4 py-1.5 text-sm font-medium text-neutral-950 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950"
+        >
+          {p.title}
+        </a>
+      ))}
+    </div>
+  )
+}
+
 function ProjectDetails({
   project,
   shape,
@@ -18,7 +42,7 @@ function ProjectDetails({
   children?: React.ReactNode
 }) {
   return (
-    <div className="group/section [counter-increment:section]">
+    <div id={projectSlug(project)} className="group/section scroll-mt-24 [counter-increment:section]">
       <div className="lg:flex lg:items-center lg:justify-end lg:gap-x-8 lg:group-even/section:justify-start xl:gap-x-20">
         <div className="flex justify-center">
           <FadeIn className="w-[33.75rem] flex-none lg:w-[45rem]">
@@ -68,39 +92,33 @@ function ProjectDetails({
   )
 }
 
-export async function Projects() {
-  const projects = await loadProjects()
-
+function ProjectsList({ projects }: { projects: Project[] }) {
   return (
     <div className="mt-18 space-y-18 [counter-reset:section]">
-      {projects
-        .sort((a, b) => a.order - b.order)
-        .map((project, idx) => {
-          return (
-            <ProjectDetails project={project} key={project.title} shape={(idx % 3) as 0 | 1 | 2}>
-              {project.abstract}
-            </ProjectDetails>
-          )
-        })}
+      {projects.map((project, idx) => (
+        <ProjectDetails project={project} key={project.title} shape={(idx % 3) as 0 | 1 | 2}>
+          {project.abstract}
+        </ProjectDetails>
+      ))}
     </div>
   )
 }
 
-export default function ProjectSection() {
+export async function Projects() {
+  const projects = (await loadProjects()).sort((a, b) => a.order - b.order)
+  return <ProjectsList projects={projects} />
+}
+
+export default async function ProjectSection() {
+  const projects = (await loadProjects()).sort((a, b) => a.order - b.order)
   return (
     <div>
       <Section
         eyebrow="Projects"
         title="A Curated Collection of My Projects and Related Documentation."
-        description={
-          <>
-            <Button href="https://trello.com/b/LqyE5lHq/project-tracking" className="mt-6">
-              Projects Tracker
-            </Button>
-          </>
-        }
+        description={<QuickLinks projects={projects} />}
       >
-        <Projects />
+        <ProjectsList projects={projects} />
       </Section>
       <QuoteBanner author={{ name: 'Guy Kawasaki' }}>Ideas are easy. Implementation is hard</QuoteBanner>
     </div>

--- a/src/test/e2e/links.spec.ts
+++ b/src/test/e2e/links.spec.ts
@@ -23,10 +23,17 @@ test.describe('External and internal links', () => {
     await page.goto('/projects')
     // QuickLinks renders one chip per project, each linking to an in-page anchor
     // matching the project's slug (the section card sets matching id={slug}).
-    const anchorChip = page.locator('a[href^="#"]').first()
-    await expect(anchorChip).toBeVisible()
-    const href = await anchorChip.getAttribute('href')
-    expect(href).toMatch(/^#[a-z0-9-]+$/)
+    const anchorChips = page.locator('a[href^="#"]')
+    const count = await anchorChips.count()
+    expect(count).toBeGreaterThan(0)
+    for (let i = 0; i < count; i++) {
+      const chip = anchorChips.nth(i)
+      await expect(chip).toBeVisible()
+      const href = await chip.getAttribute('href')
+      expect(href).toMatch(/^#[a-z0-9-]+$/)
+      const targetId = href!.slice(1)
+      await expect(page.locator(`#${targetId}`)).toHaveCount(1)
+    }
   })
 
   test('404 page home link points to /', async ({ page }) => {

--- a/src/test/e2e/links.spec.ts
+++ b/src/test/e2e/links.spec.ts
@@ -19,10 +19,14 @@ test.describe('External and internal links', () => {
     await expect(coffeeLink).toHaveAttribute('href', 'https://www.buymeacoffee.com/8bitalex')
   })
 
-  test('Projects Tracker button has Trello URL', async ({ page }) => {
+  test('Projects page has anchor quick-links to each project', async ({ page }) => {
     await page.goto('/projects')
-    const trackerLink = page.getByRole('link', { name: /Projects Tracker/i })
-    await expect(trackerLink).toHaveAttribute('href', /trello\.com/)
+    // QuickLinks renders one chip per project, each linking to an in-page anchor
+    // matching the project's slug (the section card sets matching id={slug}).
+    const anchorChip = page.locator('a[href^="#"]').first()
+    await expect(anchorChip).toBeVisible()
+    const href = await anchorChip.getAttribute('href')
+    expect(href).toMatch(/^#[a-z0-9-]+$/)
   })
 
   test('404 page home link points to /', async ({ page }) => {


### PR DESCRIPTION
## Summary

Drops the Trello "Projects Tracker" button on /projects and replaces it with a row of pill-style anchor links — one per project — that scroll the visitor down to the matching card without leaving the page.

## What changed

- **`src/components/sections/Projects.tsx`**
  - New `QuickLinks` component renders a wrap-friendly row of pill chips. Hover + focus-visible states match the existing visual language.
  - Each chip targets `#<slug>` where slug is derived from the project href (`/projects/<slug>`).
  - Each `ProjectDetails` card now has matching `id={slug}` + `scroll-mt-24` so anchor jumps land below the sticky header.
  - Section refactored: projects load once in `ProjectSection` and feed both `QuickLinks` and `ProjectsList` instead of double-loading.

- **`src/test/e2e/links.spec.ts`**
  - Removed the "Projects Tracker button has Trello URL" assertion (no longer applicable).
  - Added an assertion that anchor chips exist and point at slug-shaped fragment identifiers.

## Test plan

- npm run build clean
- 181 unit tests still pass
- Visual + click-through check on the CF Pages preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)