### PR TITLE
fix(blog): redo Uppy cooldown graphs to actually reflect the formula

### DIFF
--- a/src/app/blog/uppy-technical-deep-dive/page.mdx
+++ b/src/app/blog/uppy-technical-deep-dive/page.mdx
@@ -152,24 +152,12 @@ cooldown_ms(N) = min(15000, round(1500 + 2032 · log₂(max(1, N))))
 
 Three things to notice. At N=1 (solo), the cooldown is **1.5 seconds**, which feels snappy. The constant **2032** was picked empirically — playtest, tweak, playtest, tweak — until the curve felt right at small and medium lobbies. And there's a **hard cap at 15 seconds**, so no individual player ever has to wait longer than that regardless of how big the lobby gets.
 
-Here's how the per-player cooldown scales:
-
 <div style={{margin: '2rem 0', textAlign: 'center'}}>
 <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" style={{maxWidth: '100%', height: 'auto'}}>
   <defs>
-    <style>{`
-      .axis { stroke: #111; stroke-width: 1.5; fill: none; }
-      .grid { stroke: #ddd; stroke-width: 1; fill: none; stroke-dasharray: 3 3; }
-      .curve { stroke: #2563eb; stroke-width: 2.5; fill: none; }
-      .limit { stroke: #dc2626; stroke-width: 1.5; fill: none; stroke-dasharray: 6 4; }
-      .lbl { font: 500 11px -apple-system, sans-serif; fill: #333; }
-      .lbl-axis { font: 600 12px -apple-system, sans-serif; fill: #111; }
-      .lbl-curve { font: 600 11px -apple-system, sans-serif; }
-      .dot { fill: #2563eb; }
-    `}</style>
+    <style>{}</style>
   </defs>
-  {/* Plot area: x 60..680 (620px), y 30..300 (270px). X: log2(N) from 0 (N=1) to 9 (N=512). Y: 0..18 seconds */}
-  {/* Grid lines (Y at every 3s) */}
+  {/* Plot area: x 60..680 (linear N 0..200, x=60+N*3.1), y 30..300 (0..18 sec, y=300-cd*15) */}
   <line className="grid" x1="60" y1="300" x2="680" y2="300" />
   <line className="grid" x1="60" y1="255" x2="680" y2="255" />
   <line className="grid" x1="60" y1="210" x2="680" y2="210" />
@@ -177,40 +165,23 @@ Here's how the per-player cooldown scales:
   <line className="grid" x1="60" y1="120" x2="680" y2="120" />
   <line className="grid" x1="60" y1="75" x2="680" y2="75" />
   <line className="grid" x1="60" y1="30" x2="680" y2="30" />
-  {/* X gridlines at log-spaced N values */}
   <line className="grid" x1="60" y1="30" x2="60" y2="300" />
-  <line className="grid" x1="129" y1="30" x2="129" y2="300" />
-  <line className="grid" x1="198" y1="30" x2="198" y2="300" />
-  <line className="grid" x1="267" y1="30" x2="267" y2="300" />
-  <line className="grid" x1="336" y1="30" x2="336" y2="300" />
-  <line className="grid" x1="404" y1="30" x2="404" y2="300" />
-  <line className="grid" x1="473" y1="30" x2="473" y2="300" />
-  <line className="grid" x1="542" y1="30" x2="542" y2="300" />
-  <line className="grid" x1="611" y1="30" x2="611" y2="300" />
+  <line className="grid" x1="137.5" y1="30" x2="137.5" y2="300" />
+  <line className="grid" x1="215" y1="30" x2="215" y2="300" />
+  <line className="grid" x1="292.5" y1="30" x2="292.5" y2="300" />
+  <line className="grid" x1="370" y1="30" x2="370" y2="300" />
+  <line className="grid" x1="447.5" y1="30" x2="447.5" y2="300" />
+  <line className="grid" x1="525" y1="30" x2="525" y2="300" />
+  <line className="grid" x1="602.5" y1="30" x2="602.5" y2="300" />
   <line className="grid" x1="680" y1="30" x2="680" y2="300" />
-  {/* 15s limit line */}
   <line className="limit" x1="60" y1="75" x2="680" y2="75" />
   <text className="lbl-curve" fill="#dc2626" x="670" y="68" textAnchor="end">15s hard cap</text>
-  {/* The curve. Sample at log2 stops, points = (60 + log2(N)/9 * 620, 300 - cd(N)/18 * 270) */}
-  {/* N=1 (log2=0, cd=1.5): x=60, y=300 - 1.5/18*270 = 300-22.5 = 277.5 */}
-  {/* N=2 (log2=1, cd=3.53): x=128.9, y=300 - 53 = 247 */}
-  {/* N=4 (log2=2, cd=5.56): x=197.8, y=300 - 83.4 = 216.6 */}
-  {/* N=8 (log2=3, cd=7.6): x=266.7, y=300 - 114 = 186 */}
-  {/* N=16 (log2=4, cd=9.63): x=335.6, y=300 - 144.45 = 155.55 */}
-  {/* N=32 (log2=5, cd=11.66): x=404.4, y=300 - 174.9 = 125.1 */}
-  {/* N=64 (log2=6, cd=13.69): x=473.3, y=300 - 205.35 = 94.65 */}
-  {/* N=100 cap (log2=6.64, cd=15): x=60+6.64/9*620=60+457.7=517.7, y=75 */}
-  {/* N=128 (log2=7, cd=15): x=542.2, y=75 */}
-  {/* N=256 (log2=8, cd=15): x=611.1, y=75 */}
-  {/* N=512 (log2=9, cd=15): x=680, y=75 */}
-  <polyline className="curve" points="60,277.5 128.9,247 197.8,216.6 266.7,186 335.6,155.55 404.4,125.1 473.3,94.65 517.7,75 680,75" />
-  {/* Inflection dot */}
-  <circle className="dot" cx="517.7" cy="75" r="4" />
-  <text className="lbl-curve" fill="#2563eb" x="525" y="93">cap at N≈100</text>
-  {/* Axes */}
+  <line className="ref" x1="370" y1="75" x2="370" y2="300" />
+  <text className="lbl-curve" fill="#666" x="378" y="293">cap at N=100</text>
+  <polyline className="curve" points="63.1,277.50 66.2,247.02 69.3,229.19 72.4,216.54 75.5,206.73 78.6,198.70 81.7,191.93 84.8,186.06 87.9,180.88 91.0,176.25 94.1,172.05 97.2,168.22 100.3,164.72 103.4,161.44 106.5,158.41 109.6,155.58 112.7,152.91 115.8,150.41 118.9,148.02 122.0,145.77 125.1,143.62 128.2,141.57 131.3,139.62 134.4,137.75 137.5,135.96 140.6,134.23 143.7,132.57 146.8,130.97 149.9,129.44 153.0,127.94 156.1,126.50 159.2,125.10 162.3,123.75 165.4,122.43 168.5,121.16 171.6,119.92 174.7,118.71 177.8,117.54 180.9,116.40 184.0,115.29 187.1,114.19 190.2,113.14 193.3,112.11 196.4,111.09 199.5,110.11 202.6,109.14 205.7,108.19 208.8,107.26 211.9,106.36 215.0,105.48 218.1,104.61 221.2,103.75 224.3,102.92 227.4,102.09 230.5,101.28 233.6,100.48 236.7,99.72 239.8,98.95 242.9,98.19 246.0,97.45 249.1,96.73 252.2,96.01 255.3,95.31 258.4,94.62 261.5,93.94 264.6,93.27 267.7,92.61 270.8,91.95 273.9,91.31 277.0,90.68 280.1,90.06 283.2,89.44 286.3,88.83 289.4,88.23 292.5,87.65 295.6,87.06 298.7,86.49 301.8,85.92 304.9,85.37 308.0,84.81 311.1,84.26 314.2,83.72 317.3,83.19 320.4,82.66 323.5,82.14 326.6,81.63 329.7,81.12 332.8,80.61 335.9,80.11 339.0,79.63 342.1,79.14 345.2,78.66 348.3,78.18 351.4,77.71 354.5,77.25 357.6,76.78 360.7,76.34 363.8,75.88 366.9,75.44 370.0,75.00 373.1,75.00 376.2,75.00 379.3,75.00 382.4,75.00 385.5,75.00 388.6,75.00 391.7,75.00 394.8,75.00 397.9,75.00 401.0,75.00 404.1,75.00 407.2,75.00 410.3,75.00 413.4,75.00 416.5,75.00 419.6,75.00 422.7,75.00 425.8,75.00 428.9,75.00 432.0,75.00 435.1,75.00 438.2,75.00 441.3,75.00 444.4,75.00 447.5,75.00 450.6,75.00 453.7,75.00 456.8,75.00 459.9,75.00 463.0,75.00 466.1,75.00 469.2,75.00 472.3,75.00 475.4,75.00 478.5,75.00 481.6,75.00 484.7,75.00 487.8,75.00 490.9,75.00 494.0,75.00 497.1,75.00 500.2,75.00 503.3,75.00 506.4,75.00 509.5,75.00 512.6,75.00 515.7,75.00 518.8,75.00 521.9,75.00 525.0,75.00 528.1,75.00 531.2,75.00 534.3,75.00 537.4,75.00 540.5,75.00 543.6,75.00 546.7,75.00 549.8,75.00 552.9,75.00 556.0,75.00 559.1,75.00 562.2,75.00 565.3,75.00 568.4,75.00 571.5,75.00 574.6,75.00 577.7,75.00 580.8,75.00 583.9,75.00 587.0,75.00 590.1,75.00 593.2,75.00 596.3,75.00 599.4,75.00 602.5,75.00 605.6,75.00 608.7,75.00 611.8,75.00 614.9,75.00 618.0,75.00 621.1,75.00 624.2,75.00 627.3,75.00 630.4,75.00 633.5,75.00 636.6,75.00 639.7,75.00 642.8,75.00 645.9,75.00 649.0,75.00 652.1,75.00 655.2,75.00 658.3,75.00 661.4,75.00 664.5,75.00 667.6,75.00 670.7,75.00 673.8,75.00 676.9,75.00 680.0,75.00" />
+  <circle className="dot" cx="370" cy="75" r="4" />
   <line className="axis" x1="60" y1="30" x2="60" y2="300" />
   <line className="axis" x1="60" y1="300" x2="680" y2="300" />
-  {/* Y axis labels */}
   <text className="lbl" x="55" y="304" textAnchor="end">0</text>
   <text className="lbl" x="55" y="259" textAnchor="end">3</text>
   <text className="lbl" x="55" y="214" textAnchor="end">6</text>
@@ -219,42 +190,30 @@ Here's how the per-player cooldown scales:
   <text className="lbl" x="55" y="79" textAnchor="end">15</text>
   <text className="lbl" x="55" y="34" textAnchor="end">18</text>
   <text className="lbl-axis" x="20" y="165" textAnchor="middle" transform="rotate(-90, 20, 165)">Cooldown (seconds)</text>
-  {/* X axis labels — N values at log2 stops */}
-  <text className="lbl" x="60" y="318" textAnchor="middle">1</text>
-  <text className="lbl" x="129" y="318" textAnchor="middle">2</text>
-  <text className="lbl" x="198" y="318" textAnchor="middle">4</text>
-  <text className="lbl" x="267" y="318" textAnchor="middle">8</text>
-  <text className="lbl" x="336" y="318" textAnchor="middle">16</text>
-  <text className="lbl" x="404" y="318" textAnchor="middle">32</text>
-  <text className="lbl" x="473" y="318" textAnchor="middle">64</text>
-  <text className="lbl" x="542" y="318" textAnchor="middle">128</text>
-  <text className="lbl" x="611" y="318" textAnchor="middle">256</text>
-  <text className="lbl" x="680" y="318" textAnchor="middle">512</text>
-  <text className="lbl-axis" x="370" y="345" textAnchor="middle">Players in lobby (log scale)</text>
+  <text className="lbl" x="60" y="318" textAnchor="middle">0</text>
+  <text className="lbl" x="137.5" y="318" textAnchor="middle">25</text>
+  <text className="lbl" x="215" y="318" textAnchor="middle">50</text>
+  <text className="lbl" x="292.5" y="318" textAnchor="middle">75</text>
+  <text className="lbl" x="370" y="318" textAnchor="middle">100</text>
+  <text className="lbl" x="447.5" y="318" textAnchor="middle">125</text>
+  <text className="lbl" x="525" y="318" textAnchor="middle">150</text>
+  <text className="lbl" x="602.5" y="318" textAnchor="middle">175</text>
+  <text className="lbl" x="680" y="318" textAnchor="middle">200</text>
+  <text className="lbl-axis" x="370" y="345" textAnchor="middle">Players in lobby</text>
 </svg>
-<div style={{fontSize: '12px', color: '#666', marginTop: '4px'}}>Per-player cooldown vs. lobby size. The curve is logarithmic — each doubling of players adds the same ~2 seconds to the cooldown — until the 15-second cap takes over around 100 players.</div>
+<div style={{fontSize: '12px', color: '#666', marginTop: '4px'}}>Per-player cooldown grows logarithmically with lobby size — fast climb at the start, slowing as the lobby grows, then flat at the 15-second cap once the lobby exceeds ~100 players.</div>
 </div>
 
-The first thing to notice is that **doubling the number of players adds the same fixed cost to the cooldown, not a multiplicative one**. From 1 to 2 players adds ~2 seconds. From 2 to 4 adds ~2 seconds. From 4 to 8 adds ~2 seconds. Logarithmic by construction. The result is that at small lobby sizes (2–8 people, the sweet spot for actual play sessions) the cooldown grows quickly enough that players feel the pressure mounting, but the floor (1.5 seconds) and ceiling (15 seconds) keep both ends of the range playable.
+The first thing to notice is the **shape**: a fast climb at the start (every new player matters a lot when you're 2-vs-3), tapering as the lobby grows (the 50th player adds much less to the cooldown than the 5th), then a hard plateau once the cap kicks in around 100 players. That's the logarithmic formula doing its job — each *doubling* of players adds the same ~2 seconds to the cooldown, which on a linear x-axis looks like the curve above. At small lobby sizes (2-8 people, the sweet spot for actual play sessions) the cooldown grows quickly enough that players feel the pressure mounting; the floor (1.5 seconds) and ceiling (15 seconds) keep both ends of the range playable.
 
 The second graph is the one that actually drives the gameplay feel. If everyone in the lobby is tapping at the maximum allowed rate, how many taps per second can the lobby collectively produce?
 
 <div style={{margin: '2rem 0', textAlign: 'center'}}>
 <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" style={{maxWidth: '100%', height: 'auto'}}>
   <defs>
-    <style>{`
-      .axis { stroke: #111; stroke-width: 1.5; fill: none; }
-      .grid { stroke: #ddd; stroke-width: 1; fill: none; stroke-dasharray: 3 3; }
-      .curve { stroke: #16a34a; stroke-width: 2.5; fill: none; }
-      .ref { stroke: #888; stroke-width: 1; fill: none; stroke-dasharray: 4 4; }
-      .lbl { font: 500 11px -apple-system, sans-serif; fill: #333; }
-      .lbl-axis { font: 600 12px -apple-system, sans-serif; fill: #111; }
-      .lbl-curve { font: 600 11px -apple-system, sans-serif; }
-      .dot { fill: #16a34a; }
-    `}</style>
+    <style>{}</style>
   </defs>
-  {/* Plot area: x 60..680, y 30..300. X: linear N from 0 to 200. Y: 0..14 clicks/sec */}
-  {/* Gridlines */}
+  {/* Plot area: x 60..680 (linear N 0..200), y 30..300 (0..14 cps) */}
   <line className="grid" x1="60" y1="300" x2="680" y2="300" />
   <line className="grid" x1="60" y1="261" x2="680" y2="261" />
   <line className="grid" x1="60" y1="223" x2="680" y2="223" />
@@ -263,42 +222,21 @@ The second graph is the one that actually drives the gameplay feel. If everyone 
   <line className="grid" x1="60" y1="107" x2="680" y2="107" />
   <line className="grid" x1="60" y1="69" x2="680" y2="69" />
   <line className="grid" x1="60" y1="30" x2="680" y2="30" />
-  {/* X grid every 25 players: x = 60 + N/200 * 620 */}
   <line className="grid" x1="60" y1="30" x2="60" y2="300" />
-  <line className="grid" x1="138" y1="30" x2="138" y2="300" />
+  <line className="grid" x1="137.5" y1="30" x2="137.5" y2="300" />
   <line className="grid" x1="215" y1="30" x2="215" y2="300" />
-  <line className="grid" x1="293" y1="30" x2="293" y2="300" />
+  <line className="grid" x1="292.5" y1="30" x2="292.5" y2="300" />
   <line className="grid" x1="370" y1="30" x2="370" y2="300" />
-  <line className="grid" x1="448" y1="30" x2="448" y2="300" />
+  <line className="grid" x1="447.5" y1="30" x2="447.5" y2="300" />
   <line className="grid" x1="525" y1="30" x2="525" y2="300" />
-  <line className="grid" x1="603" y1="30" x2="603" y2="300" />
+  <line className="grid" x1="602.5" y1="30" x2="602.5" y2="300" />
   <line className="grid" x1="680" y1="30" x2="680" y2="300" />
-  {/* Inflection at N=100: x = 60 + 100/200*620 = 370 */}
   <line className="ref" x1="370" y1="30" x2="370" y2="300" />
-  <text className="lbl-curve" fill="#666" x="378" y="44">cap inflection (N≈100)</text>
-  {/* Curve: y = 300 - max_cps(N)/14 * 270 */}
-  {/* Pre-cap (N<100): cps = N / cooldownSec(N). Post-cap (N>=100): cps = N/15 */}
-  {/* Sample dense points to capture the curve */}
-  {/* N=1: cps=0.667, x=60+3.1=63.1, y=300-12.86=287.14 */}
-  {/* N=2: 0.566, x=66.2, y=288.9 */}
-  {/* N=4: 0.719, x=72.4, y=286.13 */}
-  {/* N=8: 1.053, x=84.8, y=279.69 */}
-  {/* N=16: 1.662, x=109.6, y=267.94 */}
-  {/* N=32: 2.744, x=159.2, y=247.07 */}
-  {/* N=50: 3.69, x=215, y=228.81 */}
-  {/* N=64: 4.674, x=258.4, y=209.84 */}
-  {/* N=80: 5.59, x=308, y=192.2 */}
-  {/* N=100: 6.667 (cap inflection), x=370, y=171.43 */}
-  {/* N=125: 8.333, x=447.5, y=139.29 */}
-  {/* N=150: 10, x=525, y=107.14 */}
-  {/* N=175: 11.667, x=602.5, y=75 */}
-  {/* N=200: 13.333, x=680, y=42.86 */}
-  <polyline className="curve" points="63.1,287.14 66.2,288.9 72.4,286.13 84.8,279.69 109.6,267.94 159.2,247.07 215,228.81 258.4,209.84 308,192.2 370,171.43 447.5,139.29 525,107.14 602.5,75 680,42.86" />
+  <text className="lbl-curve" fill="#666" x="378" y="44">cap inflection (N=100)</text>
+  <polyline className="curve" points="63.1,287.14 66.2,289.08 69.3,287.74 72.4,286.14 75.5,284.49 78.6,282.86 81.7,281.26 84.8,279.69 87.9,278.14 91.0,276.62 94.1,275.13 97.2,273.66 100.3,272.20 103.4,270.77 106.5,269.35 109.6,267.95 112.7,266.57 115.8,265.19 118.9,263.83 122.0,262.49 125.1,261.15 128.2,259.83 131.3,258.51 134.4,257.21 137.5,255.91 140.6,254.63 143.7,253.35 146.8,252.08 149.9,250.81 153.0,249.56 156.1,248.31 159.2,247.07 162.3,245.84 165.4,244.61 168.5,243.39 171.6,242.17 174.7,240.96 177.8,239.75 180.9,238.55 184.0,237.35 187.1,236.17 190.2,234.98 193.3,233.79 196.4,232.62 199.5,231.44 202.6,230.28 205.7,229.11 208.8,227.95 211.9,226.80 215.0,225.64 218.1,224.49 221.2,223.35 224.3,222.21 227.4,221.07 230.5,219.93 233.6,218.80 236.7,217.67 239.8,216.54 242.9,215.43 246.0,214.30 249.1,213.19 252.2,212.07 255.3,210.96 258.4,209.85 261.5,208.74 264.6,207.64 267.7,206.54 270.8,205.45 273.9,204.35 277.0,203.26 280.1,202.17 283.2,201.08 286.3,200.00 289.4,198.91 292.5,197.83 295.6,196.75 298.7,195.67 301.8,194.60 304.9,193.52 308.0,192.45 311.1,191.39 314.2,190.32 317.3,189.25 320.4,188.19 323.5,187.13 326.6,186.07 329.7,185.02 332.8,183.96 335.9,182.91 339.0,181.85 342.1,180.81 345.2,179.76 348.3,178.71 351.4,177.67 354.5,176.62 357.6,175.58 360.7,174.54 363.8,173.50 366.9,172.47 370.0,171.43 373.1,170.14 376.2,168.86 379.3,167.57 382.4,166.29 385.5,165.00 388.6,163.71 391.7,162.43 394.8,161.14 397.9,159.86 401.0,158.57 404.1,157.29 407.2,156.00 410.3,154.71 413.4,153.43 416.5,152.14 419.6,150.86 422.7,149.57 425.8,148.29 428.9,147.00 432.0,145.71 435.1,144.43 438.2,143.14 441.3,141.86 444.4,140.57 447.5,139.29 450.6,138.00 453.7,136.71 456.8,135.43 459.9,134.14 463.0,132.86 466.1,131.57 469.2,130.29 472.3,129.00 475.4,127.71 478.5,126.43 481.6,125.14 484.7,123.86 487.8,122.57 490.9,121.29 494.0,120.00 497.1,118.71 500.2,117.43 503.3,116.14 506.4,114.86 509.5,113.57 512.6,112.29 515.7,111.00 518.8,109.71 521.9,108.43 525.0,107.14 528.1,105.86 531.2,104.57 534.3,103.29 537.4,102.00 540.5,100.71 543.6,99.43 546.7,98.14 549.8,96.86 552.9,95.57 556.0,94.29 559.1,93.00 562.2,91.71 565.3,90.43 568.4,89.14 571.5,87.86 574.6,86.57 577.7,85.29 580.8,84.00 583.9,82.71 587.0,81.43 590.1,80.14 593.2,78.86 596.3,77.57 599.4,76.29 602.5,75.00 605.6,73.71 608.7,72.43 611.8,71.14 614.9,69.86 618.0,68.57 621.1,67.29 624.2,66.00 627.3,64.71 630.4,63.43 633.5,62.14 636.6,60.86 639.7,59.57 642.8,58.29 645.9,57.00 649.0,55.71 652.1,54.43 655.2,53.14 658.3,51.86 661.4,50.57 664.5,49.29 667.6,48.00 670.7,46.71 673.8,45.43 676.9,44.14 680.0,42.86" />
   <circle className="dot" cx="370" cy="171.43" r="4" />
-  {/* Axes */}
   <line className="axis" x1="60" y1="30" x2="60" y2="300" />
   <line className="axis" x1="60" y1="300" x2="680" y2="300" />
-  {/* Y labels */}
   <text className="lbl" x="55" y="304" textAnchor="end">0</text>
   <text className="lbl" x="55" y="265" textAnchor="end">2</text>
   <text className="lbl" x="55" y="227" textAnchor="end">4</text>
@@ -308,19 +246,18 @@ The second graph is the one that actually drives the gameplay feel. If everyone 
   <text className="lbl" x="55" y="73" textAnchor="end">12</text>
   <text className="lbl" x="55" y="34" textAnchor="end">14</text>
   <text className="lbl-axis" x="20" y="165" textAnchor="middle" transform="rotate(-90, 20, 165)">Max clicks per second</text>
-  {/* X labels */}
   <text className="lbl" x="60" y="318" textAnchor="middle">0</text>
-  <text className="lbl" x="138" y="318" textAnchor="middle">25</text>
+  <text className="lbl" x="137.5" y="318" textAnchor="middle">25</text>
   <text className="lbl" x="215" y="318" textAnchor="middle">50</text>
-  <text className="lbl" x="293" y="318" textAnchor="middle">75</text>
+  <text className="lbl" x="292.5" y="318" textAnchor="middle">75</text>
   <text className="lbl" x="370" y="318" textAnchor="middle">100</text>
-  <text className="lbl" x="448" y="318" textAnchor="middle">125</text>
+  <text className="lbl" x="447.5" y="318" textAnchor="middle">125</text>
   <text className="lbl" x="525" y="318" textAnchor="middle">150</text>
-  <text className="lbl" x="603" y="318" textAnchor="middle">175</text>
+  <text className="lbl" x="602.5" y="318" textAnchor="middle">175</text>
   <text className="lbl" x="680" y="318" textAnchor="middle">200</text>
-  <text className="lbl-axis" x="370" y="345" textAnchor="middle">Players in lobby (linear scale)</text>
+  <text className="lbl-axis" x="370" y="345" textAnchor="middle">Players in lobby</text>
 </svg>
-<div style={{fontSize: '12px', color: '#666', marginTop: '4px'}}>Max collective tap rate (N ÷ cooldown_seconds) vs. lobby size. Below the cap (~100 players) the curve grows sub-linearly — the cooldown is "winning" against the player count. Above the cap, the cooldown stops rising and tap rate grows linearly at N/15.</div>
+<div style={{fontSize: '12px', color: '#666', marginTop: '4px'}}>Max collective tap rate (N / cooldown_seconds) vs. lobby size. Below the cap (~100 players) the curve grows sub-linearly — the cooldown is "winning" against the player count. Above the cap, the cooldown stops rising and tap rate grows linearly at N/15.</div>
 </div>
 
 This is where the cooperative-feel design pays off. The pre-cap region — which is where almost all real lobbies live — is sub-linear. **Adding more players helps less than you'd expect.** Going from 8 players to 16 doesn't double your tap rate; it adds maybe 60%. The team isn't getting easier to be on, it's getting harder to keep coordinated. Players who panic-tap waste their cooldown; players who pace themselves contribute more per tap.

--- a/src/app/blog/uppy-technical-deep-dive/page.mdx
+++ b/src/app/blog/uppy-technical-deep-dive/page.mdx
@@ -155,7 +155,17 @@ Three things to notice. At N=1 (solo), the cooldown is **1.5 seconds**, which fe
 <div style={{margin: '2rem 0', textAlign: 'center'}}>
 <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" style={{maxWidth: '100%', height: 'auto'}}>
   <defs>
-    <style>{}</style>
+    <style>{`
+      .axis { stroke: #111; stroke-width: 1.5; fill: none; }
+      .grid { stroke: #ddd; stroke-width: 1; fill: none; stroke-dasharray: 3 3; }
+      .curve { stroke: #2563eb; stroke-width: 2.5; fill: none; }
+      .limit { stroke: #dc2626; stroke-width: 1.5; fill: none; stroke-dasharray: 6 4; }
+      .ref { stroke: #888; stroke-width: 1; fill: none; stroke-dasharray: 4 4; }
+      .lbl { font: 500 11px -apple-system, sans-serif; fill: #333; }
+      .lbl-axis { font: 600 12px -apple-system, sans-serif; fill: #111; }
+      .lbl-curve { font: 600 11px -apple-system, sans-serif; }
+      .dot { fill: #2563eb; }
+    `}</style>
   </defs>
   {/* Plot area: x 60..680 (linear N 0..200, x=60+N*3.1), y 30..300 (0..18 sec, y=300-cd*15) */}
   <line className="grid" x1="60" y1="300" x2="680" y2="300" />
@@ -211,7 +221,16 @@ The second graph is the one that actually drives the gameplay feel. If everyone 
 <div style={{margin: '2rem 0', textAlign: 'center'}}>
 <svg viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" style={{maxWidth: '100%', height: 'auto'}}>
   <defs>
-    <style>{}</style>
+    <style>{`
+      .axis { stroke: #111; stroke-width: 1.5; fill: none; }
+      .grid { stroke: #ddd; stroke-width: 1; fill: none; stroke-dasharray: 3 3; }
+      .curve { stroke: #16a34a; stroke-width: 2.5; fill: none; }
+      .ref { stroke: #888; stroke-width: 1; fill: none; stroke-dasharray: 4 4; }
+      .lbl { font: 500 11px -apple-system, sans-serif; fill: #333; }
+      .lbl-axis { font: 600 12px -apple-system, sans-serif; fill: #111; }
+      .lbl-curve { font: 600 11px -apple-system, sans-serif; }
+      .dot { fill: #16a34a; }
+    `}</style>
   </defs>
   {/* Plot area: x 60..680 (linear N 0..200), y 30..300 (0..14 cps) */}
   <line className="grid" x1="60" y1="300" x2="680" y2="300" />


### PR DESCRIPTION
## Summary

The previous Graph 1 used a log-scale x-axis. That technically rendered the formula correctly (a logarithmic function on a log-x is a straight line), but it read wrong to anyone expecting the characteristic log-curve shape the formula implies. Graph 2 was also slightly off around N=50 due to a hand-eyeballed value.

## What changed

- **Both graphs now use a linear x-axis (0..200 players)** so the formulas actual shape is visible:
  - Graph 1 shows the sharp early rise, gradual tapering, and the flat plateau once the 15s cap engages at N=100
  - Graph 2 shows the early dip (where the cooldown is winning), the slow sub-linear climb, the cap-inflection at N=100, and the linear N/15 growth past that
- **200 dense sample points per graph**, generated directly from the cooldown.ts formula via Python (one sample per player)
- **Matching axis tick positions on both** so they compare side by side
- **Updated the prose** between Heres how the per-player cooldown scales and the chart to describe what readers see on the new linear-x rendering, while still calling out the underlying logarithmic doubling adds ~2 seconds property

🤖 Generated with [Claude Code](https://claude.com/claude-code)