### PR TITLE
feat(blog): add tag system + per-tag listing pages

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,13 +1,8 @@
 import { type Metadata } from 'next'
-import Image from 'next/image'
-import Link from 'next/link'
 
-import { Border } from '@/components/Border'
-import { Button } from '@/components/Button'
-import { FadeIn } from '@/components/FadeIn'
+import { ArticleList } from '@/components/blocks/ArticleList'
 import { Container } from '@/components/layout/Container'
 import { PageIntro } from '@/components/PageIntro'
-import { formatDate } from '@/lib/formatDate'
 import { loadPosts } from '@/lib/mdx'
 
 export const metadata: Metadata = {
@@ -18,52 +13,33 @@ export const metadata: Metadata = {
 
 export default async function Blog() {
   const articles = await loadPosts()
+  // Collect unique tags across all posts for the topic-chips row.
+  const allTags = Array.from(new Set(articles.flatMap((a) => a.tags ?? []))).sort((a, b) =>
+    a.localeCompare(b)
+  )
 
   return (
     <>
       <PageIntro eyebrow="Blog" title="Articles, Announcements, and More">
         <p>{metadata.description}</p>
+        {allTags.length > 0 && (
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-neutral-600">Topics:</span>
+            {allTags.map((tag) => (
+              <a
+                key={tag}
+                href={`/blog/tags/${tag.toLowerCase()}`}
+                className="inline-flex items-center rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-700 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white"
+              >
+                {tag}
+              </a>
+            ))}
+          </div>
+        )}
       </PageIntro>
 
       <Container className="mt-24 sm:mt-32 lg:mt-40">
-        <div className="space-y-24 lg:space-y-32">
-          {articles
-            .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-            .map((article) => (
-              <FadeIn key={article.href}>
-                <article>
-                  <Border className="pt-16">
-                    <div className="relative lg:-mx-4 lg:flex lg:justify-end">
-                      <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
-                        <h2 className="font-display text-2xl font-semibold text-neutral-950">
-                          <Link href={article.href}>{article.title}</Link>
-                        </h2>
-                        <dl className="lg:absolute lg:top-0 lg:left-0 lg:w-1/3 lg:px-4">
-                          <dt className="sr-only">Published</dt>
-                          <dd className="absolute top-0 left-0 text-sm text-neutral-950 lg:static">
-                            <time dateTime={article.date}>{formatDate(article.date)}</time>
-                          </dd>
-                          <dt className="sr-only">Author</dt>
-                          <dd className="mt-6 flex gap-x-4">
-                            <div className="flex-none overflow-hidden rounded-xl bg-neutral-100">
-                              <Image alt="" {...article.author.image} className="h-12 w-12 object-cover grayscale" />
-                            </div>
-                            <div className="text-sm text-neutral-950">
-                              <div className="font-semibold">{article.author.name}</div>
-                            </div>
-                          </dd>
-                        </dl>
-                        <p className="mt-6 max-w-2xl text-base text-neutral-600">{article.description}</p>
-                        <Button href={article.href} aria-label={`Read more: ${article.title}`} className="mt-8">
-                          Read more
-                        </Button>
-                      </div>
-                    </div>
-                  </Border>
-                </article>
-              </FadeIn>
-            ))}
-        </div>
+        <ArticleList articles={articles} />
       </Container>
     </>
   )

--- a/src/app/blog/raid-design-proposal/page.mdx
+++ b/src/app/blog/raid-design-proposal/page.mdx
@@ -8,6 +8,8 @@ export const post = {
   title: 'Raid: A Tool for Orchestrating Distributed Application Development',
   description:
     'My design proposal for Raid, an open-source command-line tool that streamlines development across distributed codebases. Raid orchestrates tasks, environments, and dependencies through a simple, configurable YAML system.'
+,
+  tags: ['Raid']
 }
 
 export const metadata = {

--- a/src/app/blog/raid-technical-deep-dive/page.mdx
+++ b/src/app/blog/raid-technical-deep-dive/page.mdx
@@ -8,6 +8,8 @@ export const post = {
   title: 'Building Raid: A Technical Deep Dive',
   description:
     'A year after the design proposal, an honest retrospective on _Raid_ — the multi-repo workflow orchestrator I built to escape my own toil. Architecture, key design decisions (including agent-native MCP integration), what got cut, and what I learned along the way.'
+,
+  tags: ['Raid']
 }
 
 export const metadata = {

--- a/src/app/blog/tags/[tag]/page.tsx
+++ b/src/app/blog/tags/[tag]/page.tsx
@@ -1,0 +1,68 @@
+import { type Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { ArticleList } from '@/components/blocks/ArticleList'
+import { Container } from '@/components/layout/Container'
+import { PageIntro } from '@/components/PageIntro'
+import { loadPosts } from '@/lib/mdx'
+
+// Statically generate one page per unique tag found across the posts.
+// Slug is the lowercased tag; display name is the original case-preserved
+// tag we find on the matched posts (so "Uppy" stays "Uppy", not "uppy").
+export async function generateStaticParams() {
+  const posts = await loadPosts()
+  const tags = new Set<string>()
+  for (const p of posts) for (const t of p.tags ?? []) tags.add(t.toLowerCase())
+  return Array.from(tags).map((tag) => ({ tag }))
+}
+
+interface Params {
+  params: Promise<{ tag: string }>
+}
+
+async function findTagDisplayName(slug: string): Promise<string | null> {
+  const posts = await loadPosts()
+  for (const p of posts) {
+    for (const t of p.tags ?? []) {
+      if (t.toLowerCase() === slug) return t
+    }
+  }
+  return null
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { tag } = await params
+  const display = await findTagDisplayName(tag)
+  if (!display) return { title: 'Tag' }
+  return {
+    title: `${display} — Blog`,
+    description: `Blog posts tagged ${display}.`
+  }
+}
+
+export default async function TagPage({ params }: Params) {
+  const { tag } = await params
+  const display = await findTagDisplayName(tag)
+  if (!display) notFound()
+  const articles = (await loadPosts()).filter((p) =>
+    (p.tags ?? []).some((t) => t.toLowerCase() === tag)
+  )
+
+  return (
+    <>
+      <PageIntro eyebrow={`Topic: ${display}`} title={`Posts tagged ${display}`}>
+        <p>
+          Every blog post tagged <strong>{display}</strong>, newest first.{' '}
+          <a href="/blog" className="underline hover:text-neutral-950">
+            See all posts
+          </a>
+          .
+        </p>
+      </PageIntro>
+
+      <Container className="mt-24 sm:mt-32 lg:mt-40">
+        <ArticleList articles={articles} />
+      </Container>
+    </>
+  )
+}

--- a/src/app/blog/uppy-technical-deep-dive/page.mdx
+++ b/src/app/blog/uppy-technical-deep-dive/page.mdx
@@ -8,6 +8,8 @@ export const post = {
   title: 'Building Uppy: A Technical Deep Dive',
   description:
     'A silly co-op multiplayer browser game built entirely on the Cloudflare edge stack. Why Durable Objects are the right primitive for multiplayer state, the math behind the cooldown that makes the game cooperative instead of competitive, and what it taught me about WebSockets at scale.'
+,
+  tags: ['Uppy']
 }
 
 export const metadata = {

--- a/src/app/blog/wrapper.tsx
+++ b/src/app/blog/wrapper.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { FadeIn } from '@/components/FadeIn'
 import { Container } from '@/components/layout/Container'
 import { MDXComponents } from '@/components/MDXComponents'
@@ -27,6 +29,19 @@ export default async function BlogArticleWrapper({
               {formatDate(post.date)}
             </time>
             <p className="mt-6 text-sm font-semibold text-neutral-950">by {post.author.name}</p>
+            {post.tags && post.tags.length > 0 && (
+              <div className="mt-6 flex flex-wrap justify-center gap-2">
+                {post.tags.map((tag) => (
+                  <Link
+                    key={tag}
+                    href={`/blog/tags/${tag.toLowerCase()}`}
+                    className="inline-flex items-center rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-700 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white"
+                  >
+                    {tag}
+                  </Link>
+                ))}
+              </div>
+            )}
           </header>
         </FadeIn>
 

--- a/src/components/blocks/ArticleList.tsx
+++ b/src/components/blocks/ArticleList.tsx
@@ -1,0 +1,70 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { Border } from '@/components/Border'
+import { Button } from '@/components/Button'
+import { FadeIn } from '@/components/FadeIn'
+import { formatDate } from '@/lib/formatDate'
+import { type MDXEntry, type Post } from '@/lib/mdx'
+
+// Shared list of blog articles. Used on the /blog index and on every
+// /blog/tags/[tag] filter page. Articles are rendered in descending date
+// order so the caller can hand in either the full set or a tag-filtered subset.
+export function ArticleList({ articles }: { articles: Array<MDXEntry<Post>> }) {
+  if (articles.length === 0) {
+    return <p className="text-center text-neutral-600">No posts here yet.</p>
+  }
+  return (
+    <div className="space-y-24 lg:space-y-32">
+      {articles
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .map((article) => (
+          <FadeIn key={article.href}>
+            <article>
+              <Border className="pt-16">
+                <div className="relative lg:-mx-4 lg:flex lg:justify-end">
+                  <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
+                    <h2 className="font-display text-2xl font-semibold text-neutral-950">
+                      <Link href={article.href}>{article.title}</Link>
+                    </h2>
+                    <dl className="lg:absolute lg:top-0 lg:left-0 lg:w-1/3 lg:px-4">
+                      <dt className="sr-only">Published</dt>
+                      <dd className="absolute top-0 left-0 text-sm text-neutral-950 lg:static">
+                        <time dateTime={article.date}>{formatDate(article.date)}</time>
+                      </dd>
+                      <dt className="sr-only">Author</dt>
+                      <dd className="mt-6 flex gap-x-4">
+                        <div className="flex-none overflow-hidden rounded-xl bg-neutral-100">
+                          <Image alt="" {...article.author.image} className="h-12 w-12 object-cover grayscale" />
+                        </div>
+                        <div className="text-sm text-neutral-950">
+                          <div className="font-semibold">{article.author.name}</div>
+                        </div>
+                      </dd>
+                    </dl>
+                    <p className="mt-6 max-w-2xl text-base text-neutral-600">{article.description}</p>
+                    {article.tags && article.tags.length > 0 && (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {article.tags.map((tag) => (
+                          <Link
+                            key={tag}
+                            href={`/blog/tags/${tag.toLowerCase()}`}
+                            className="inline-flex items-center rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-700 transition hover:border-neutral-950 hover:bg-neutral-950 hover:text-white"
+                          >
+                            {tag}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                    <Button href={article.href} aria-label={`Read more: ${article.title}`} className="mt-8">
+                      Read more
+                    </Button>
+                  </div>
+                </div>
+              </Border>
+            </article>
+          </FadeIn>
+        ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a tag/category system to the blog so the Uppy and Raid posts can group under their respective topics.

## What changed

- **Tagged the three existing posts**: `tags: [Uppy]` on the Uppy deep dive, `tags: [Raid]` on both Raid posts.
- **New dynamic route**: `src/app/blog/tags/[tag]/page.tsx` with `generateStaticParams` so each tag becomes its own static page at build time. Build output now includes `/blog/tags/uppy` and `/blog/tags/raid`. Adding a tag to any future post auto-generates the matching page on the next build.
- **Extracted ArticleList component**: `src/components/blocks/ArticleList.tsx` shared between `/blog` and the tag pages.
- **Tag chips** show in three places: the post header (centered, below byline), each article card on `/blog` and `/blog/tags/*`, and a "Topics:" row on `/blog`.

## Test plan

- npm run build clean
- Build output confirms two static tag pages generated: /blog/tags/uppy, /blog/tags/raid
- /blog/tags/uppy contains only the Uppy post; /blog/tags/raid contains both Raid posts
- Unknown tag (e.g. /blog/tags/foo) 404s via Next notFound()

Companion PR on uppy-game adds a Read about Uppy on the blog link in the join card that points at /blog/tags/uppy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)