### PR TITLE
blog: 13 Raid tutorial articles (living series)

### DIFF
--- a/src/app/blog/how-to-add-a-health-check-to-a-raid-workflow/page.mdx
+++ b/src/app/blog/how-to-add-a-health-check-to-a-raid-workflow/page.mdx
@@ -1,0 +1,214 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Add a Health Check to a Raid Workflow',
+  description:
+    'Use the Raid `Wait` task to block on HTTP endpoints or TCP ports until a service is healthy — and pair it with `Group` for retry semantics on flaky deps.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'health check', 'Wait task', 'service readiness',
+    'docker-compose', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-add-a-health-check-to-a-raid-workflow' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+A lot of Raid workflows look like: start a thing, then talk to it. Start the dev server, then run tests against it. Bring up docker-compose, then seed the database. The race between "the service is started" and "the service is ready" eats most of the flaky-test budget on a typical team.
+
+The `Wait` task fixes that. It blocks until an HTTP endpoint returns healthy or a TCP port accepts connections, then lets the next task run.
+
+## 1. The `Wait` task
+
+`Wait` accepts a target and a timeout. The target is either an HTTP URL or a `host:port` TCP address:
+
+```yaml
+- type: Wait
+  url: http://localhost:8080/health
+  timeout: 30s
+```
+
+Raid polls the URL until either:
+
+- it gets a healthy response (HTTP 2xx or 3xx; TCP accept), at which point the task succeeds and the command continues; or
+- the `timeout:` elapses, at which point the task fails with `TASK_WAIT_TIMEOUT` and exit code 3.
+
+The default timeout is 30s. Set it explicitly when you know a service needs longer — `60s`, `2m`, etc. Standard Go duration syntax applies.
+
+## 2. HTTP vs TCP
+
+Both are first-class:
+
+```yaml
+# HTTP — best for app services with a dedicated /health or /healthz route
+- type: Wait
+  url: http://localhost:8080/health
+
+# TCP — best for raw services like postgres, redis, kafka
+- type: Wait
+  url: localhost:5432
+```
+
+For databases and caches, TCP is usually enough — once the port accepts a connection, the protocol layer is ready to handshake. For application services, HTTP gives you a clean signal that the *application* is up, not just the listener.
+
+## 3. The classic "start, wait, work" pattern
+
+The most useful shape — boot infra, wait for it, do something that depends on it:
+
+```yaml
+commands:
+  - name: dev
+    usage: Start the local stack and seed it
+    tasks:
+      - type: Shell
+        cmd: docker compose -f ./infra/local.yml up -d
+      - type: Wait
+        url: localhost:5432
+        timeout: 60s
+      - type: Wait
+        url: http://localhost:8080/health
+        timeout: 60s
+      - type: Shell
+        cmd: ./scripts/seed-db.sh
+      - type: Print
+        message: Stack is up and seeded.
+        color: green
+```
+
+`raid dev` brings up compose, blocks until Postgres and the API are both reachable, seeds the database, and reports.
+
+## 4. Waiting on multiple things in parallel
+
+If two services start independently, fan the waits out — both timers run at once, the command continues when both are ready:
+
+```yaml
+- type: Wait
+  url: http://localhost:8080/health
+  timeout: 60s
+  concurrent: true
+- type: Wait
+  url: http://localhost:8090/health
+  timeout: 60s
+```
+
+See [How to run tasks in parallel with Raid](/blog/how-to-run-tasks-in-parallel-with-raid) for the full concurrent-task model.
+
+## 5. Retry semantics on flaky deps
+
+`Wait` polls but does not "retry" in the usual sense — once it gives up at the timeout, the whole task fails. If the dependency is genuinely flaky and you want explicit retry behavior, wrap the wait in a `Group`:
+
+```yaml
+- type: Group
+  ref: wait-for-api
+  attempts: 3
+  delay: 10s
+```
+
+…and define the `wait-for-api` block elsewhere as a `Wait` (or a `Wait` + a `Shell` healthcheck). The Group will run the block up to three times, waiting 10 seconds between attempts.
+
+## 6. Pairing with `raid install`
+
+`Wait` is especially useful inside profile-level install tasks. After a `docker compose up -d`, wait for the dependencies to come ready before any seeding script runs:
+
+```yaml
+# profile.raid.yaml
+install:
+  tasks:
+    - type: Shell
+      cmd: docker compose -f ./infra/local.yml up -d
+    - type: Wait
+      url: localhost:5432
+      timeout: 60s
+    - type: Wait
+      url: localhost:6379
+      timeout: 30s
+    - type: Shell
+      cmd: ./scripts/migrate.sh
+    - type: Shell
+      cmd: ./scripts/seed.sh
+```
+
+That sequence is what makes `raid install` reliable on day one — no race conditions, no "did Postgres come up yet?" trial-and-error.
+
+## 7. Pre-flight checks before user commands
+
+You can also add `Wait` to user-facing commands as a pre-flight check. If `raid test` needs the API up, declare it:
+
+```yaml
+commands:
+  - name: test
+    usage: Run the integration tests against the local API
+    tasks:
+      - type: Wait
+        url: http://localhost:8080/health
+        timeout: 5s
+      - type: Shell
+        cmd: npm test
+```
+
+If the API isn't running, `raid test` fails fast with a clear "wait timeout" message instead of running the test suite and failing with a confusing connection error.
+
+## 8. Common gotchas
+
+- **Health endpoint that returns 200 too early.** A service can answer `/health` before it's done warming up its connection pool. Make your health endpoint actually check downstream dependencies before returning 200, or wait for a more specific endpoint.
+- **TCP wait against a service behind a proxy.** Waiting on the proxy's port doesn't tell you the upstream is ready. Wait on the actual application endpoint via HTTP instead.
+- **Too-short timeouts in CI.** Cold runners can take 30+ seconds to bring containers up. Be generous in CI — a 60-second timeout that succeeds in 5 is fine; a 5-second timeout that flakes once a week burns hours.
+
+## Next steps
+
+- [How to Run Tasks in Parallel with Raid](/blog/how-to-run-tasks-in-parallel-with-raid) — fan-out waits and Group retry semantics.
+- [How to Clone All Your Team's Repos with `raid install`](/blog/how-to-clone-all-your-team-repos-with-raid-install) — where most health checks naturally fit.
+- [How to Debug a Failing Raid Task](/blog/how-to-debug-a-failing-raid-task) — when the wait times out and you need to figure out why.

--- a/src/app/blog/how-to-add-a-raid-yaml-to-an-existing-repo/page.mdx
+++ b/src/app/blog/how-to-add-a-raid-yaml-to-an-existing-repo/page.mdx
@@ -1,0 +1,235 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Add a raid.yaml to an Existing Repo',
+  description:
+    'Commit a raid.yaml to any repo so the Raid CLI can run its commands, environments, and install steps — and merge them with the team profile automatically.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'raid.yaml', 'repo config', 'multi-repo development',
+    'developer tooling', 'YAML', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-add-a-raid-yaml-to-an-existing-repo' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+A `raid.yaml` is the per-repo counterpart to a Raid profile. The profile lives at the team level and describes *which repos exist* and *what environments are available*. The `raid.yaml` lives inside each repo and describes *what's specific to this repo* — its commands, its install steps, its environment overrides.
+
+This guide walks through adding one to a repo from scratch.
+
+## 1. Where it goes
+
+Put `raid.yaml` at the **root of the repo**, alongside `README.md` / `package.json` / `go.mod`. The filename must be exactly `raid.yaml` (lowercase, no profile prefix) — that's how Raid recognizes it as a repo config rather than a standalone profile.
+
+```
+your-repo/
+├── raid.yaml          ← here
+├── package.json
+└── src/
+```
+
+## 2. The minimum
+
+The smallest useful `raid.yaml` defines a single command:
+
+```yaml
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
+name: frontend
+commands:
+  - name: dev
+    usage: Run the dev server with hot reload
+    tasks:
+      - type: Shell
+        cmd: npm run dev
+```
+
+Commit it. Anyone running `raid dev` from anywhere on disk will now run `npm run dev` inside this repo.
+
+The schema header gives you completion and validation in any editor with `yaml-language-server` (VS Code, JetBrains, Neovim).
+
+## 3. The full surface
+
+A `raid.yaml` accepts six top-level fields. You only use the ones you need:
+
+```yaml
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
+name: frontend           # display name (defaults to directory name)
+branch: main             # default branch for git ops
+
+verify:                  # preconditions checked before commands run
+  - cmd: node --version
+
+install:                 # what `raid install` runs for this repo
+  tasks:
+    - type: Shell
+      cmd: npm ci
+
+environments:            # per-repo overrides on top of profile envs
+  - name: local
+    variables:
+      - { name: API_URL, value: http://localhost:8080 }
+
+commands:                # user-facing `raid <name>` subcommands
+  - name: dev
+    usage: Run the dev server
+    tasks:
+      - type: Shell
+        cmd: npm run dev
+  - name: test
+    usage: Run the unit tests
+    tasks:
+      - type: Shell
+        cmd: npm test
+```
+
+## 4. How it merges with the profile
+
+When the team profile loads, Raid reads every repo's `raid.yaml` and **merges** them. The rules are predictable:
+
+- **`commands`** — appended. If the profile and the repo both define `dev`, the **profile** wins (so platform-level commands are stable).
+- **`install` tasks** — appended; the repo's run after the profile's.
+- **`environments`** — merged by name. If both define an `local` env, **variables are concatenated**, repo entries can override matching keys on a per-key basis, and the profile's tasks run before the repo's.
+- **`verify`** — appended.
+
+The practical effect: the team profile sets the *shape* of the environment (which envs exist, what commands are guaranteed to be there). Each `raid.yaml` adds repo-specific commands and environment values without fighting the profile.
+
+## 5. Common patterns
+
+### Wrap your existing scripts
+
+If you already have `npm run` / `make` / `just` recipes, just shell them out:
+
+```yaml
+commands:
+  - name: build
+    tasks:
+      - type: Shell
+        cmd: make build
+  - name: lint
+    tasks:
+      - type: Shell
+        cmd: npm run lint
+```
+
+That gives you `raid build` / `raid lint` everywhere, without rewriting your existing tooling.
+
+### A repo-specific install step
+
+If the repo needs `npm ci` and a one-time codegen pass on first clone:
+
+```yaml
+install:
+  tasks:
+    - type: Shell
+      cmd: npm ci
+    - type: Shell
+      cmd: npm run codegen
+```
+
+`raid install` will run those after the repo is cloned.
+
+### Pin a local env value
+
+Most env vars belong in the **profile** so every developer agrees on them. But sometimes a repo has a value only meaningful inside it (e.g. its own port):
+
+```yaml
+environments:
+  - name: local
+    variables:
+      - { name: PORT, value: '3000' }
+```
+
+The profile-level `local` env still sets shared values; this repo's `local` adds `PORT` on top.
+
+### Add a precondition
+
+`verify` runs before any command. Use it to catch missing tools fast:
+
+```yaml
+verify:
+  - cmd: node --version
+  - cmd: docker --version
+```
+
+If either fails, Raid stops with a clear error instead of letting the actual command crash partway through.
+
+## 6. Test it locally
+
+You don't need a profile to try a `raid.yaml`. Add it directly:
+
+```bash
+raid profile add ./raid.yaml
+```
+
+When the filename is literally `raid.yaml`, Raid synthesizes a single-repo profile from it. You can run the commands immediately to verify they work, then remove the profile (`raid profile remove <name>`) and let the team profile pick it up later.
+
+## 7. Commit it
+
+`raid.yaml` is part of the repo. Commit it like any other config file:
+
+```bash
+git add raid.yaml
+git commit -m "chore: add raid.yaml — commands, install, local env"
+```
+
+From this point on, every developer on the team gets the same `raid dev`, `raid test`, `raid build`, regardless of which repo they're standing in.
+
+## Next steps
+
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — the team-level wrapper that ties multiple `raid.yaml` files together.
+- [How to Define a Custom Command in Raid](/blog/how-to-define-a-custom-command-in-raid) — the eleven task types and how to compose them.
+- [How to Switch Environments with `raid env`](/blog/how-to-switch-environments-with-raid-env) — what merging actually does at runtime.

--- a/src/app/blog/how-to-clone-all-your-team-repos-with-raid-install/page.mdx
+++ b/src/app/blog/how-to-clone-all-your-team-repos-with-raid-install/page.mdx
@@ -1,0 +1,191 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: "How to Clone All Your Team's Repos with raid install",
+  description:
+    'Bootstrap a multi-repo workspace in one command. `raid install` clones every repo in your profile in parallel, runs install tasks, and is fully idempotent.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'raid install', 'clone repos', 'multi-repo bootstrap',
+    'developer onboarding', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-clone-all-your-team-repos-with-raid-install' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+The first thing a new hire usually does on day one is clone the repos. With five services and a couple of shared libs, that's the rest of the morning. `raid install` collapses that into a single command — it reads the active profile, clones every repo in parallel, and runs each repo's `install:` tasks.
+
+This guide covers the basic flow, the flags that matter, and how `raid install` behaves on subsequent runs.
+
+## 1. The basic flow
+
+Assuming you've already added a profile (see [How to create a Raid profile](/blog/how-to-create-a-raid-profile)):
+
+```bash
+raid install
+```
+
+Raid does, in order:
+
+1. Reads the active profile and the list of repositories in it.
+2. **Clones every repo in parallel** to the `path:` defined for each.
+3. Runs the profile-level `install: tasks:` sequence.
+4. Reports a summary.
+
+The order is intentional — repos exist before any install task touches them, so an `npm ci` in a freshly cloned `frontend` repo will find its `package.json`.
+
+## 2. Capping parallelism
+
+`raid install` clones every repo concurrently by default. On a constrained network or a self-hosted runner with bandwidth limits, cap the parallelism with `--threads N` (or `-t N`):
+
+```bash
+raid install --threads 4
+```
+
+Four concurrent clones at a time. Worth a lower number on flaky connections; the default is fine on most local machines.
+
+## 3. Installing a single repo
+
+Sometimes you only want to bootstrap one repo — you added a new service to the profile and don't want to re-walk the others:
+
+```bash
+raid install <repo-name>
+```
+
+Clones just that repo (or skips the clone if it's already there) and runs that repo's `install:` tasks. **Profile-level install tasks are skipped** in single-repo mode — those are for whole-environment bootstrap, not per-service top-ups.
+
+## 4. Idempotency
+
+`raid install` is safe to re-run. A repo that's already at its `path:` is skipped, not re-cloned. Install tasks always run — they're expected to be idempotent themselves (`npm ci` is fine; a destructive bootstrap script that wipes state is not).
+
+A few cases worth knowing:
+
+- **Repo path exists, repo not cloned (e.g. empty directory):** Raid will use it as the clone target. Make sure it's actually empty if you don't want git to refuse.
+- **Repo with no `url:` (local-only):** if the path exists, Raid uses it as-is. If the path doesn't exist, Raid errors out — there's no remote to clone from.
+- **Already-cloned repo at a different remote:** Raid does not change the remote. It assumes you intentionally renamed something and leaves the working copy alone.
+
+## 5. Per-repo install tasks
+
+Each repo's `raid.yaml` can declare its own `install:` block — the per-repo bootstrap:
+
+```yaml
+# frontend/raid.yaml
+install:
+  tasks:
+    - type: Shell
+      cmd: npm ci
+    - type: Shell
+      cmd: npm run codegen
+```
+
+`raid install` runs the profile-level tasks first, then each repo's tasks in the order their repos are listed in the profile.
+
+This is the natural place for `npm ci` / `pip install` / `cargo fetch` / `make tools` — anything the repo needs to be runnable after a fresh clone.
+
+## 6. The `install` block at profile level
+
+A profile can also declare its own `install:` tasks — for cross-repo bootstrap (priming a shared database, generating a TLS cert, starting a docker-compose stack):
+
+```yaml
+# acme.raid.yaml
+install:
+  tasks:
+    - type: Shell
+      cmd: docker compose -f ./infra/local.yml up -d
+    - type: Wait
+      url: http://localhost:5432
+      timeout: 30s
+    - type: Shell
+      cmd: ./scripts/seed-db.sh
+```
+
+Profile-level tasks run **after** all repos are cloned and before per-repo install tasks. Useful for infra that every repo's install depends on.
+
+## 7. Failure handling
+
+If a clone fails, Raid reports the failure for that repo and continues with the others (a single repo's network blip shouldn't block the rest of the install). Once all clones are done, install tasks run only for the repos that successfully cloned.
+
+The exit code is **4 (Network)** when any clone failed, **3 (Task)** when an install task failed, **0** on full success. See [How to wire Raid into CI](/blog/how-to-wire-raid-into-ci) for using the categories.
+
+## 8. The day-one onboarding flow
+
+Putting it together, day one looks like:
+
+```bash
+# Install raid
+brew install 8bitalex/tap/raid
+
+# Register the team profile
+raid profile add git@github.com:acme/raid-profiles.git
+
+# Clone and bootstrap everything
+raid install
+
+# Pick the env
+raid env local
+
+# Start the dev server
+raid dev
+```
+
+Five commands and the new hire is running the stack — no wiki archaeology, no Slack threads.
+
+## Next steps
+
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — the file `raid install` reads from.
+- [How to Add a `raid.yaml` to an Existing Repo](/blog/how-to-add-a-raid-yaml-to-an-existing-repo) — where per-repo install tasks live.
+- [How to Add a Health Check to a Raid Workflow](/blog/how-to-add-a-health-check-to-a-raid-workflow) — pairing `Wait` with install for "start service, wait for it, run seed".

--- a/src/app/blog/how-to-debug-a-failing-raid-task/page.mdx
+++ b/src/app/blog/how-to-debug-a-failing-raid-task/page.mdx
@@ -1,0 +1,185 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Debug a Failing Raid Task',
+  description:
+    'Diagnose Raid failures fast: read the exit-code category, decode the structured error envelope, use `raid context`, and apply per-task `continueOnFailure` for noisy steps.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'debug', 'troubleshooting', 'exit codes',
+    'structured errors', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-debug-a-failing-raid-task' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+When a `raid` command fails, the first instinct is usually to scroll up looking for a stack trace. Raid is more disciplined than that: every failure carries a category, an error code, a message, and often a hint. This guide walks through reading them, common categories of failure, and a few flags that help isolate the cause.
+
+## 1. Read the exit code first
+
+Raid maps failures to five categorical exit codes. They tell you *what kind* of thing went wrong without reading any logs:
+
+| Exit code | Category   | Typical cause                                                |
+| --------- | ---------- | ------------------------------------------------------------ |
+| 1         | Generic    | Unclassified — fall-through; treat as bug report material    |
+| 2         | Config     | Invalid profile / repo YAML / argument                       |
+| 3         | Task       | A user task failed (shell exit non-zero, prompt missing default, wait timeout) |
+| 4         | Network    | Clone failed, HTTP task failed                               |
+| 5         | Not Found  | Profile / env / command / repo / file missing                |
+
+Print `$?` (POSIX) / `$LASTEXITCODE` (PowerShell) right after the failed run to see it. The category alone narrows the cause to one of five buckets.
+
+## 2. Decode the structured error
+
+Raid surfaces a typed error object. In text mode it prints a prose line:
+
+```
+Error: profile 'web-platform' not found (PROFILE_NOT_FOUND)
+Hint: use 'raid profile list' to see available profiles
+```
+
+In `--json` mode it emits a stable envelope:
+
+```json
+{
+  "error": {
+    "code": "PROFILE_NOT_FOUND",
+    "category": "not-found",
+    "message": "profile 'web-platform' not found",
+    "hint": "use 'raid profile list' to see available profiles"
+  }
+}
+```
+
+`code` is the most stable identifier — assert on it in scripts. `hint` is the fastest path to the fix.
+
+## 3. Common failure codes and how to react
+
+| Code                          | Category | Where it comes from                                  | Likely fix                                                |
+| ----------------------------- | -------- | --------------------------------------------------- | --------------------------------------------------------- |
+| `PROFILE_INVALID`             | Config   | Profile file failed schema validation               | Check the `# yaml-language-server` errors in your editor  |
+| `PROFILE_NOT_ACTIVE`          | Not Found| No profile is active                                | `raid profile list` then `raid profile <name>`            |
+| `PROFILE_NOT_FOUND`           | Not Found| Named profile isn't registered                      | `raid profile list` to confirm; re-add if missing         |
+| `REPO_NOT_CLONED`             | Not Found| Command needs a repo that's not on disk             | `raid install` or `raid install <repo>`                   |
+| `COMMAND_NOT_FOUND`           | Not Found| `raid foo` and no `foo` command exists              | `raid --help` for the actual list                         |
+| `ENV_NOT_FOUND`               | Not Found| `raid env staging` but no `staging` env defined     | `raid env list` to confirm naming                          |
+| `TASK_SHELL_FAILED`           | Task     | A `Shell` task exited non-zero                       | Read the shell's own stderr; that's where the real cause is |
+| `TASK_WAIT_TIMEOUT`           | Task     | `Wait` task exhausted its `timeout:`                | The dependency isn't coming up — check it directly        |
+| `HEADLESS_PROMPT_NO_DEFAULT`  | Task     | Headless mode hit a Prompt without a `default:`     | Add a `default:` or set the var via env before running    |
+| `CLONE_FAILED`                | Network  | Git couldn't clone a repo                            | SSH key, repo URL, or network                             |
+| `TASK_HTTP_FAILED`            | Network  | `HTTP` task got a non-2xx or couldn't reach the URL | URL right? Auth right? Service up?                        |
+| `SCHEMA_VALIDATION_FAILED`    | Config   | YAML doesn't match the published schema             | Editor LSP usually pinpoints the line                     |
+
+The full list is more — but these cover the majority of day-to-day failures.
+
+## 4. Inspect the workspace state
+
+When the cause isn't immediately obvious from the error, dump the current state:
+
+```bash
+raid context --json | jq .
+```
+
+That returns active profile, active env, every repo with its git state (branch, dirty?), and recently-run commands. Half the "why doesn't this work" failures resolve here:
+
+- The repo isn't cloned (`repos[*].cloned` is false).
+- It's on the wrong branch (`repos[*].branch`).
+- Local edits are blocking a checkout (`repos[*].dirty` is true).
+- The env isn't what you thought it was.
+
+For agent-driven debug, `raid context serve` gives the same data over MCP — see [How to use Raid as an MCP server](/blog/how-to-use-raid-as-an-mcp-server).
+
+## 5. Re-run with more output
+
+A failing `Shell` task already passes its stderr through. If you need more from Raid itself:
+
+- **`--json`** — emits the error envelope verbatim, including all detail fields (not all of which print in text mode).
+- **Re-run the failing shell directly.** Find the `cmd:` in the YAML, change into the repo, and run it. If the bug reproduces, it's not Raid — it's the underlying tool.
+- **Run a single task in isolation.** Comment out the surrounding tasks in the command and re-run. Once you've isolated the failing task, the cause is usually obvious.
+
+## 6. Tolerate expected failures
+
+Sometimes a step is allowed to fail — a clean-up command that may or may not have anything to clean, a probe that's informational. Mark the task `continueOnFailure: true` so the command keeps going:
+
+```yaml
+- type: Shell
+  cmd: rm -rf ./.cache
+  options:
+    continueOnFailure: true
+```
+
+The task's failure is logged but doesn't abort the command. The command's overall exit code is still 0 if everything else succeeded.
+
+Don't use this to paper over real bugs — but for genuinely best-effort steps, it's the right tool.
+
+## 7. Headless / CI debugging
+
+A few flags help when you're staring at a CI log instead of a live terminal:
+
+- **`--json`** — easier to grep than prose.
+- **`RAID_NO_PREFIX=1`** — drops the `[task-name]` prefix on concurrent output so plain logs are easier to read.
+- **Bisect via `--threads 1`** — for `raid install`, reduce clone parallelism to 1 to make logs strictly sequential.
+
+## 8. When it's actually a Raid bug
+
+If you've checked the code, the error message is wrong or misleading, and `raid context` shows expected state, you've probably hit a Raid bug. Open an issue at [github.com/8bitAlex/raid/issues](https://github.com/8bitAlex/raid/issues) with the error code, the exit code, and a minimal `raid.yaml` that reproduces it.
+
+## Next steps
+
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — the flags that complement debugging in CI.
+- [How to Use Raid as an MCP Server for AI Agents](/blog/how-to-use-raid-as-an-mcp-server) — get an agent to inspect the workspace state for you.
+- [Raid technical deep dive](/blog/raid-technical-deep-dive) — the underlying error model.

--- a/src/app/blog/how-to-define-a-custom-command-in-raid/page.mdx
+++ b/src/app/blog/how-to-define-a-custom-command-in-raid/page.mdx
@@ -1,0 +1,287 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Define a Custom Command in Raid',
+  description:
+    'Define a custom `raid <name>` command by composing the eleven built-in task types — Shell, Script, Git, HTTP, Wait, Template, Prompt, Confirm, Print, Set, and Group.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'custom command', 'task runner', 'YAML',
+    'developer tooling', 'shell task', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-define-a-custom-command-in-raid' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+A Raid command is a named sequence of tasks. Once defined, it's available as a first-class `raid <name>` subcommand — auto-listed in `raid --help`, invocable from anywhere on disk, and runnable in CI without changes.
+
+This guide walks through writing one from scratch and tours the eleven built-in task types.
+
+## 1. The minimum command
+
+A command has a name, an optional `usage:` line for `--help`, and a `tasks:` array. The smallest useful one is one task long:
+
+```yaml
+commands:
+  - name: dev
+    usage: Run the dev server with hot reload
+    tasks:
+      - type: Shell
+        cmd: npm run dev
+```
+
+Run it from anywhere:
+
+```bash
+raid dev
+```
+
+Raid resolves the command, switches to the repo's directory, and runs the task.
+
+## 2. Where to define them
+
+Commands can live at two levels:
+
+- **Profile-level** (in `*.raid.yaml`) — show up as platform-wide commands. Ideal for things every developer should be able to run.
+- **Repo-level** (in `raid.yaml` inside a repo) — show up the same way; specific to that repo.
+
+When both define the same name, the profile wins. That keeps platform-level commands stable even when individual repos drift.
+
+## 3. Tour: the eleven task types
+
+Every task has a `type:`, and Raid ships with eleven of them. All accept an optional `name:` (shown in output), `concurrent: true` (run alongside the next task), and a `condition:` block (skip unless platform/file/command matches).
+
+### Shell
+
+Run a shell command. The workhorse:
+
+```yaml
+- type: Shell
+  cmd: npm test
+  shell: bash       # optional: bash | sh | zsh | powershell | pwsh | cmd
+  path: ./packages/api   # optional: working directory
+```
+
+### Script
+
+Run a script file. Pick the runner explicitly:
+
+```yaml
+- type: Script
+  path: ./scripts/deploy.sh
+  runner: bash      # bash | sh | zsh | python | python3 | node | powershell
+```
+
+### Set
+
+Set a variable for later tasks (with `$VAR` / `${VAR}` expansion):
+
+```yaml
+- type: Set
+  var: VERSION
+  value: $(git rev-parse --short HEAD)
+  default: dev       # used if value expansion yields empty
+```
+
+### Git
+
+A typed wrapper over common git operations — easier to read in YAML than a Shell task:
+
+```yaml
+- type: Git
+  op: pull           # pull | checkout | fetch | reset
+  branch: main
+  path: ./
+```
+
+### HTTP
+
+Download a file:
+
+```yaml
+- type: HTTP
+  url: https://example.com/seed.sql
+  dest: ./data/seed.sql
+```
+
+### Wait
+
+Wait for a TCP port or an HTTP endpoint to become healthy:
+
+```yaml
+- type: Wait
+  url: http://localhost:8080/health
+  timeout: 60s
+```
+
+Works with bare `host:port` too — useful for waiting on a database to accept connections.
+
+### Template
+
+Render a template file with variable expansion and write the output:
+
+```yaml
+- type: Template
+  src: ./templates/config.tmpl
+  dest: ./config/local.yaml
+```
+
+### Prompt
+
+Ask the user for a value, store it in a variable:
+
+```yaml
+- type: Prompt
+  var: ENVIRONMENT
+  message: Which environment?
+  default: local
+```
+
+In headless mode (`--yes`, `--headless`, `RAID_HEADLESS=1`, or `--json`), the `default:` is used. Without one, the task fails with a clear error — see [How to wire Raid into CI](/blog/how-to-wire-raid-into-ci).
+
+### Confirm
+
+Pause for a `y`/`yes`:
+
+```yaml
+- type: Confirm
+  message: Deploy to production?
+```
+
+Auto-accepts in headless mode.
+
+### Print
+
+Print to the terminal — handy for status updates and section dividers:
+
+```yaml
+- type: Print
+  message: Build complete.
+  color: green       # red | green | yellow | blue | cyan | white
+```
+
+### Group
+
+Group several tasks together — useful for retry / parallelism semantics on a logical unit:
+
+```yaml
+- type: Group
+  ref: build-and-test
+  parallel: false
+  attempts: 3
+  delay: 5s
+```
+
+`Group` references a named block defined elsewhere — see the [Raid technical deep dive](/blog/raid-technical-deep-dive) for the longer pattern.
+
+## 4. Composing a real command
+
+Most useful commands chain a few task types together. Example: a `release` command that prompts for a version, builds, waits for tests to settle, and prints a summary.
+
+```yaml
+commands:
+  - name: release
+    usage: Cut a new release of the API
+    tasks:
+      - type: Prompt
+        var: VERSION
+        message: Version to release (e.g. 1.4.0)?
+      - type: Shell
+        cmd: npm run build
+      - type: Shell
+        cmd: npm test
+      - type: Wait
+        url: http://localhost:8080/health
+        timeout: 30s
+      - type: Print
+        message: Release ${VERSION} built and tested.
+        color: green
+```
+
+`raid release` walks the tasks top-to-bottom, halting on the first failure (unless a task opts into `options.continueOnFailure: true`).
+
+## 5. Useful options on every task
+
+Each task supports a few optional knobs that aren't a `type:` value:
+
+- `name:` — friendly label for output (defaults to the type)
+- `options.showExeTime: true` — print elapsed time after the task
+- `options.continueOnFailure: true` — log the failure but don't halt the command
+- `concurrent: true` — run alongside the next task instead of sequentially (see [How to run tasks in parallel](/blog/how-to-run-tasks-in-parallel-with-raid))
+- `condition:` — skip the task unless a platform / file / command matches:
+  ```yaml
+  - type: Shell
+    cmd: brew install jq
+    condition:
+      platform: darwin
+  ```
+
+## 6. Verify it landed
+
+After saving, your command shows up automatically:
+
+```bash
+raid --help
+```
+
+The new entry appears alongside the built-ins under user-defined commands.
+
+## Next steps
+
+- [How to Run Tasks in Parallel with Raid](/blog/how-to-run-tasks-in-parallel-with-raid) — when and why to use `concurrent`.
+- [How to Use Templates and Prompts in Raid Tasks](/blog/how-to-use-templates-and-prompts-in-raid-tasks) — interactive flows in detail.
+- [How to Debug a Failing Raid Task](/blog/how-to-debug-a-failing-raid-task) — exit codes, verbose mode, common pitfalls.

--- a/src/app/blog/how-to-install-raid/page.mdx
+++ b/src/app/blog/how-to-install-raid/page.mdx
@@ -1,0 +1,163 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Install Raid on macOS, Linux, and Windows',
+  description:
+    'Install the Raid CLI on macOS, Linux, or Windows — stable and preview channels, verifying the install, upgrading, and uninstalling.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'install Raid', 'raid CLI install', 'macOS Homebrew',
+    'Linux install script', 'Windows CLI', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-install-raid' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-install-raid',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-install-raid#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-install-raid',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-install-raid' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', operatingSystem: 'macOS, Linux, Windows', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-install-raid' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+The Raid CLI ships as a single static binary for macOS, Linux, and Windows. This guide covers the recommended install path on each, plus the preview channel for early access and how to upgrade or uninstall.
+
+## 1. macOS — Homebrew
+
+```bash
+brew install 8bitalex/tap/raid
+```
+
+That adds the `8bitalex` tap and installs `raid` to `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel).
+
+## 2. Linux — install script
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/8bitalex/raid/main/install.sh | bash
+```
+
+The script detects your architecture (amd64 or arm64), downloads the matching release binary, and drops it in `/usr/local/bin`. Read it before piping if your security posture requires it — it's plain bash and lives in the repo.
+
+## 3. Windows — release zip
+
+1. Open the [latest release](https://github.com/8bitalex/raid/releases/latest).
+2. Download `raid_<version>_windows_amd64.zip`.
+3. Extract — you'll find `raid.exe` inside.
+4. Move `raid.exe` to a folder on your `PATH` (a common choice: `C:\Program Files\raid\`).
+5. If that folder isn't already on `PATH`, add it: **Settings → System → About → Advanced system settings → Environment Variables → Path → Edit → New** → paste the folder path.
+6. Open a new terminal window so the updated `PATH` takes effect.
+
+## 4. Verify
+
+On any platform:
+
+```bash
+raid --version
+```
+
+You should see a version string like `raid 1.x.y`. If the shell can't find `raid`, your installer didn't land it on `PATH`.
+
+## 5. Preview channel
+
+Want the latest features before they ship to stable? The preview channel is a parallel install that receives updates ahead of stable and may include experimental functionality.
+
+```bash
+# macOS / Linux
+brew install 8bitalex/tap/raid-preview
+```
+
+`raid-preview` installs alongside `raid` — same commands, different binary. Use it for testing without losing your stable install.
+
+## 6. Upgrade
+
+**Homebrew (macOS / Linux):**
+
+```bash
+brew upgrade raid
+# or for preview:
+brew upgrade raid-preview
+```
+
+**Linux install script:** re-run the same `curl ... | bash` line — it overwrites with the latest release.
+
+**Windows:** download the newer zip and replace the existing `raid.exe`.
+
+## 7. Uninstall
+
+**Homebrew:**
+
+```bash
+brew uninstall raid
+brew untap 8bitalex/tap   # optional, removes the tap entirely
+```
+
+**Linux install script:**
+
+```bash
+sudo rm /usr/local/bin/raid
+```
+
+**Windows:** delete `raid.exe` and (if you don't use it for anything else) remove its folder from `PATH`.
+
+## 8. What gets installed where
+
+| Item                                | macOS / Linux                  | Windows                        |
+| ----------------------------------- | ------------------------------ | ------------------------------ |
+| `raid` binary                       | `/usr/local/bin` or `/opt/homebrew/bin` | wherever you placed `raid.exe` |
+| Registered profiles (state)         | `~/.raid/config.yaml`          | `%USERPROFILE%\.raid\config.yaml` |
+| Persisted variables                 | `~/.raid/vars`                 | `%USERPROFILE%\.raid\vars`     |
+| Cloned repos                        | wherever the profile says      | wherever the profile says      |
+
+Profile state lives in your home directory, so reinstalling `raid` doesn't lose your configuration. Conversely, removing the binary doesn't clean up `~/.raid/` — delete that folder if you want a clean slate.
+
+## Next steps
+
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — the first thing to do after installing.
+- [How to Clone All Your Team's Repos with `raid install`](/blog/how-to-clone-all-your-team-repos-with-raid-install) — the bootstrap command you'll run next.

--- a/src/app/blog/how-to-migrate-from-make-taskfile-just-to-raid/page.mdx
+++ b/src/app/blog/how-to-migrate-from-make-taskfile-just-to-raid/page.mdx
@@ -1,0 +1,234 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Migrate from Make, Taskfile, or Just to Raid',
+  description:
+    'Move from per-project task runners (Make / Taskfile / Just / docker-compose) to Raid for multi-repo orchestration — with side-by-side conversions and a wrap-don\'t-replace strategy.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'Make', 'Makefile', 'Taskfile', 'Just', 'justfile',
+    'docker-compose', 'task runner', 'multi-repo', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-migrate-from-make-taskfile-just-to-raid' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+If your team is already comfortable with Make, Taskfile, Just, or docker-compose, the right migration to Raid isn't a rewrite — it's a wrapper. Keep your existing per-project recipes, and let Raid handle the layer above them: orchestrating across repos, switching environments, and giving the team one consistent CLI.
+
+This guide covers when to wrap vs. replace, how to convert common recipes, and what to do with docker-compose.
+
+## 1. The split: per-project vs. cross-project
+
+Make, Taskfile, and Just are great at one job: defining and running tasks **inside a single project**. They've all been refined for years, your team probably already knows them, and they belong inside each repo's `Makefile` / `Taskfile.yml` / `justfile`.
+
+Raid solves a layer up: **orchestrating the developer environment across multiple repos** — cloning them in one command, switching everyone's environment at once, exposing a single CLI that works no matter which repo you're standing in.
+
+The cleanest migration is:
+
+- **Keep** your existing `Makefile` / `Taskfile.yml` / `justfile` in each repo.
+- **Add** a `raid.yaml` that maps team-facing commands to those recipes.
+- **Add** a profile at the team level that ties the repos together and defines environments.
+
+You get Raid's multi-repo features without rewriting tasks you already trust.
+
+## 2. From Makefile to raid.yaml
+
+A typical Make recipe:
+
+```make
+.PHONY: build test deploy
+build:
+	npm run build
+test:
+	npm test
+deploy:
+	./scripts/deploy.sh
+```
+
+The `raid.yaml` wrapper:
+
+```yaml
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
+name: frontend
+commands:
+  - name: build
+    tasks: [{ type: Shell, cmd: make build }]
+  - name: test
+    tasks: [{ type: Shell, cmd: make test }]
+  - name: deploy
+    tasks: [{ type: Shell, cmd: make deploy }]
+```
+
+Net change: nothing on the Make side. The team now runs `raid build` from anywhere on disk and it does the right thing — Raid resolves the command, switches to the repo's directory, and shells out to `make`.
+
+## 3. From Taskfile to raid.yaml
+
+Taskfile recipes are a little richer (variables, deps, includes). The conversion is identical:
+
+```yaml
+# Taskfile.yml
+version: '3'
+tasks:
+  build: { cmds: [npm run build] }
+  test:  { cmds: [npm test] }
+```
+
+```yaml
+# raid.yaml
+name: api
+commands:
+  - name: build
+    tasks: [{ type: Shell, cmd: task build }]
+  - name: test
+    tasks: [{ type: Shell, cmd: task test }]
+```
+
+If you have several Taskfile recipes you'd like to expose as separate Raid commands, list them one by one. If you'd rather expose the Taskfile namespace as a single passthrough, you can — `tasks: [{ type: Shell, cmd: 'task $@' }]`-style wrappers work too.
+
+## 4. From justfile to raid.yaml
+
+Just's `justfile` recipes:
+
+```just
+build:
+    npm run build
+test:
+    npm test
+```
+
+Wrapper:
+
+```yaml
+# raid.yaml
+name: worker
+commands:
+  - name: build
+    tasks: [{ type: Shell, cmd: just build }]
+  - name: test
+    tasks: [{ type: Shell, cmd: just test }]
+```
+
+## 5. From docker-compose to a profile + per-repo raid.yaml
+
+docker-compose is the closest tool to Raid in scope — it does manage multiple services as a unit — but it does so at the *container level*, not the repo level. The two compose cleanly: docker-compose runs your service containers, Raid orchestrates the repos that contain them.
+
+A typical migration:
+
+```yaml
+# acme.raid.yaml — profile
+name: acme
+repositories:
+  - { name: frontend, path: ~/Developer/frontend, url: https://github.com/acme/frontend.git }
+  - { name: api,      path: ~/Developer/api,      url: https://github.com/acme/api.git }
+
+environments:
+  - name: local
+    variables:
+      - { name: API_URL, value: http://localhost:8080 }
+    tasks:
+      - type: Shell
+        cmd: docker compose -f ./infra/docker-compose.yml up -d
+```
+
+Now `raid env local` starts the compose stack and writes `.env` files to every repo. Developers don't need to remember to `docker compose up` separately.
+
+## 6. Cross-repo commands: the part Make can't do
+
+The above is pure wrapping — Raid exposes existing recipes through a consistent CLI. The piece that's *new* with Raid is commands that act on every repo at once. Define them at the profile level:
+
+```yaml
+commands:
+  - name: format
+    usage: Format every repo in the profile
+    tasks:
+      - type: Shell
+        cmd: make format
+        path: ~/Developer/frontend
+        concurrent: true
+      - type: Shell
+        cmd: make format
+        path: ~/Developer/api
+        concurrent: true
+```
+
+`raid format` runs both Makefiles in parallel. There's no equivalent in plain Make/Taskfile/Just — they're scoped to the single project they live in.
+
+## 7. Keep what works
+
+You don't have to migrate every recipe. A reasonable rule:
+
+- **Keep in Make/Taskfile/Just:** language- or framework-specific build steps (`tsc`, `go build`, `cargo test`). These tools have great recipe support and live close to the code.
+- **Move (wrap) into Raid:** anything the *team* should be able to run consistently — `test`, `lint`, `dev`, `deploy`. These benefit from the `raid <name>` UX and the ability to run from anywhere on disk.
+- **Define only in Raid:** cross-repo commands (`raid format`, `raid update-deps`), environment switching (`raid env staging`), and bootstrap (`raid install`).
+
+That split gives you the durability of existing per-project tooling and Raid's multi-repo features without paying for either twice.
+
+## 8. Rollout in three commits
+
+A safe migration sequence for a team:
+
+1. **Add `raid.yaml` to each repo** with wrapper commands pointing at existing recipes. Nothing changes for developers who haven't installed Raid yet.
+2. **Add the team profile** to a `raid-profiles` repo (or commit it inside the platform repo). Document `raid profile add ...` in the README.
+3. **Ask the team to install raid** — see [How to install Raid](/blog/how-to-install-raid). Old `make`/`task`/`just` workflows still work; new `raid` workflows now also work.
+
+The two coexist forever. No flag day, no rewrite, no mandate.
+
+## Next steps
+
+- [How to Add a `raid.yaml` to an Existing Repo](/blog/how-to-add-a-raid-yaml-to-an-existing-repo) — the file you'll add first.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — the team-level wrapper.
+- [How to Share a Raid Profile with Your Team](/blog/how-to-share-a-raid-profile-with-your-team) — getting everyone on the same one.

--- a/src/app/blog/how-to-run-tasks-in-parallel-with-raid/page.mdx
+++ b/src/app/blog/how-to-run-tasks-in-parallel-with-raid/page.mdx
@@ -1,0 +1,197 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Run Tasks in Parallel with Raid',
+  description:
+    'Use `concurrent: true` and Group `parallel: true` to fan out Raid tasks across CPU cores — with the safety rules, output prefixing, and when not to parallelize.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'parallel tasks', 'concurrent execution',
+    'task runner', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-run-tasks-in-parallel-with-raid' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+By default, Raid runs the tasks in a command sequentially — one at a time, halting on the first failure. That's the safe choice for most workflows. But for independent work — building three packages, downloading a few assets, pinging a few endpoints — running tasks in parallel cuts wall-clock time substantially.
+
+Raid offers two parallelism knobs: `concurrent: true` on individual tasks and `parallel: true` on Group tasks. This guide covers both, plus the output and error semantics that come with them.
+
+## 1. `concurrent: true` — task-level fan-out
+
+The simplest form: mark a task as `concurrent` and it runs **alongside** the next task instead of blocking it.
+
+```yaml
+commands:
+  - name: build-all
+    tasks:
+      - type: Shell
+        cmd: npm run build --workspace=web
+        concurrent: true
+      - type: Shell
+        cmd: npm run build --workspace=api
+        concurrent: true
+      - type: Shell
+        cmd: npm run build --workspace=worker
+```
+
+The first two tasks launch in parallel. The third starts as soon as the runtime picks it up. The command waits for *all* concurrent tasks to complete before reporting the result.
+
+**Rule of thumb:** mark every concurrent task — including the last one in a fan-out group — with `concurrent: true`. Mixing concurrent and sequential tasks is allowed but the ordering becomes harder to reason about; consistent flags make the intent obvious.
+
+## 2. Group tasks — parallelism with retry semantics
+
+For more structured work, the `Group` task type runs a named block of tasks together and supports `parallel: true`, retry attempts, and inter-attempt delay:
+
+```yaml
+- type: Group
+  ref: smoke-tests
+  parallel: true
+  attempts: 3
+  delay: 5s
+```
+
+The referenced `smoke-tests` block runs once. If it fails, Raid retries up to `attempts` times, waiting `delay` between tries. With `parallel: true`, the tasks inside the group run concurrently.
+
+Use Group when you want parallelism + retry on a logical unit (a flaky smoke-test suite, a fan-out HTTP probe). Use task-level `concurrent: true` for ad-hoc fan-out without retry.
+
+## 3. Output prefixing
+
+Concurrent tasks interleave their output. To keep things readable, Raid prefixes each line with the task's name (or type):
+
+```
+[build:web]   built dist/web/index.js
+[build:api]   compiled api in 1.4s
+[build:web]   built dist/web/styles.css
+```
+
+Disable it with the `RAID_NO_PREFIX=1` environment variable if you're piping output to a tool that expects raw stdout.
+
+## 4. Failure semantics
+
+When any concurrent task fails, Raid:
+
+1. Records the failure.
+2. **Lets other concurrent tasks finish.** It does not interrupt in-flight work.
+3. Reports the failure and exits non-zero once all concurrent tasks have completed.
+
+This mirrors how most parallel test runners behave — you get a full picture instead of a half-finished run. If you'd rather suppress an expected failure, mark that specific task with `options.continueOnFailure: true`.
+
+## 5. When *not* to parallelize
+
+Parallelism trades determinism for speed. A few situations where keeping tasks sequential is worth it:
+
+- **Shared mutable state** — two tasks writing to the same file, port, or database.
+- **Order-dependent setup** — install before build, build before test.
+- **User-facing prompts** — a `Prompt` or `Confirm` task should never share the terminal with a sibling task.
+- **Resource-bound work** — saturating CPU or disk usually doesn't make the total faster, just messier.
+
+When in doubt, leave tasks sequential. `concurrent: true` is an optimization, not a default.
+
+## 6. Pattern: parallel build + sequential test + parallel publish
+
+A realistic command structure:
+
+```yaml
+commands:
+  - name: ship
+    usage: Build, test, and publish all packages
+    tasks:
+      # Build everything in parallel
+      - type: Shell
+        cmd: npm run build --workspace=web
+        concurrent: true
+      - type: Shell
+        cmd: npm run build --workspace=api
+        concurrent: true
+      - type: Shell
+        cmd: npm run build --workspace=worker
+        concurrent: true
+
+      # Test sequentially (shared test DB)
+      - type: Shell
+        cmd: npm run test
+
+      # Publish in parallel — independent registries
+      - type: Shell
+        cmd: npm publish --workspace=web
+        concurrent: true
+      - type: Shell
+        cmd: npm publish --workspace=api
+        concurrent: true
+      - type: Shell
+        cmd: npm publish --workspace=worker
+        concurrent: true
+```
+
+Builds and publishes fan out; tests stay serial. The wall-clock time drops to roughly `max(build) + test + max(publish)` instead of the sum of every step.
+
+## 7. `raid install --threads`
+
+A separate but related knob: `raid install` clones every repo in the profile in parallel. Cap the parallelism with `--threads N` (or `-t N`) if you're on a constrained network or want to limit concurrent git operations:
+
+```bash
+raid install --threads 4
+```
+
+This applies only to the clone phase, not to install tasks (which still run in their defined order).
+
+## Next steps
+
+- [How to Define a Custom Command in Raid](/blog/how-to-define-a-custom-command-in-raid) — full tour of task types.
+- [How to Add a Health Check to a Raid Workflow](/blog/how-to-add-a-health-check-to-a-raid-workflow) — `Wait` tasks pair well with parallel startups.
+- [Raid technical deep dive](/blog/raid-technical-deep-dive) — the engine that schedules these tasks.

--- a/src/app/blog/how-to-share-a-raid-profile-with-your-team/page.mdx
+++ b/src/app/blog/how-to-share-a-raid-profile-with-your-team/page.mdx
@@ -1,0 +1,194 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Share a Raid Profile with Your Team',
+  description:
+    'Distribute a Raid CLI profile across a team — Git repo, raw URL, or committed-in-monorepo — with versioning, rollout, and update strategies.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'raid profile', 'team development', 'multi-repo',
+    'developer onboarding', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-share-a-raid-profile-with-your-team' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Once a profile works on your machine, the next step is getting everyone else on the team using the same one. Raid supports three distribution patterns: a dedicated Git repo, a raw file URL, or committing the profile inside one of your existing repos.
+
+## 1. Pick a distribution shape
+
+| Shape                          | Best when                                            | Updates                          |
+| ------------------------------ | ---------------------------------------------------- | -------------------------------- |
+| Dedicated Git repo             | You have several profiles, or a team-wide convention | PR + re-run `raid profile add`   |
+| Raw HTTPS URL (release / wiki) | One profile, hosted somewhere stable                 | Bump the URL or overwrite        |
+| Committed inside an existing repo | Profile is specific to one product / monorepo     | Just pull the repo               |
+
+All three end at the same UX: `raid profile add <something>` and you're set up. The difference is who owns the source of truth and how updates flow.
+
+## 2. Distribution via a dedicated Git repo
+
+Create a small repo (`acme/raid-profiles` is a common name) and commit your profile(s) at the root:
+
+```
+acme/raid-profiles/
+├── web-platform.raid.yaml
+├── data-platform.raid.yaml
+└── README.md
+```
+
+New hires run:
+
+```bash
+raid profile add git@github.com:acme/raid-profiles.git
+```
+
+Raid shallow-clones the repo to a temp directory and imports every `*.raid.yaml`, `*.raid.yml`, and `profile.json` it finds at the root.
+
+**When this fits:** you maintain multiple profiles (one per product, environment, or team) and want a single canonical home for all of them.
+
+**Update flow:** PRs against `acme/raid-profiles`. To pick up a new version, developers re-run `raid profile add`.
+
+## 3. Distribution via a raw HTTPS URL
+
+Host the profile as a static file — release asset, internal wiki, gist raw view, or any HTTPS URL that ends in `.yaml`, `.yml`, or `.json`:
+
+```bash
+raid profile add https://example.com/web-platform.raid.yaml
+```
+
+Raid downloads the file to `~/<name>.raid.yaml`, validates it, and registers it.
+
+**When this fits:** you've already got a place to host versioned files (GitHub releases, an internal Confluence-served-by-web-server, an S3 bucket).
+
+**Update flow:** publish a new file or bump the URL (e.g. `v2.yaml` → `v3.yaml`) and tell people to re-add.
+
+## 4. Distribution inside an existing repo
+
+If the profile is specific to a single product, commit it inside your main repo:
+
+```
+acme/web-platform/
+├── ops/
+│   └── web-platform.raid.yaml
+├── apps/
+└── ...
+```
+
+Setup becomes:
+
+```bash
+git clone git@github.com:acme/web-platform.git
+cd web-platform
+raid profile add ./ops/web-platform.raid.yaml
+```
+
+**When this fits:** the profile is product-shaped — it ties to a specific monorepo or a small fleet of repos that move together.
+
+**Update flow:** developers pull the repo. Re-adding the local file overwrites the registered copy.
+
+## 5. Versioning strategies
+
+Whichever shape you pick, version the profile like code:
+
+- **Keep it in source control.** Every change is a reviewed PR. The history tells you when a command appeared and why.
+- **Add a `version:` comment at the top.** YAML doesn't need a version field, but a comment helps humans see what they're on:
+  ```yaml
+  # web-platform profile — v3 (2026-06-03)
+  ```
+- **Use Git tags or release URLs to pin.** For Git distribution, treat the `main` branch as latest. For URL distribution, host versioned files (`v1/web-platform.raid.yaml`) so people can pin.
+- **Bump the profile when commands change.** Adding a new `raid <command>` is additive and safe; renaming or removing one is breaking and worth a PR-level callout.
+
+## 6. Onboarding a new developer
+
+The full first-day path is short:
+
+```bash
+# 1. Install raid
+brew install 8bitalex/tap/raid
+
+# 2. Add the team profile
+raid profile add git@github.com:acme/raid-profiles.git
+
+# 3. Clone and bootstrap every repo in the profile
+raid install
+
+# 4. Pick the local environment
+raid env local
+```
+
+Four commands and the new hire is running the same `raid test`, `raid deploy`, `raid env staging` as everyone else.
+
+## 7. Pushing updates
+
+A profile distributed via Git or URL is **point-in-time** — Raid imports the contents at the moment you ran `raid profile add`. It does not stay linked to the source.
+
+To push an update across the team:
+
+1. Land the change in the profile repo.
+2. Notify the team (Slack, weekly notes, etc.).
+3. Developers re-run `raid profile add <same-source>` — Raid replaces their local registration.
+
+For breaking changes (a renamed command, a removed repo), pair the announcement with a migration note.
+
+## 8. Mixing per-repo overrides
+
+Profiles aren't the whole story — each repo's `raid.yaml` adds its own commands and environment overrides on top. Distributing the profile gives everyone the same *structure*; each repo's `raid.yaml` (committed inside the repo itself) covers the per-repo specifics. See [How to add a `raid.yaml` to an existing repo](/blog/how-to-add-a-raid-yaml-to-an-existing-repo) for that side of the split.
+
+## Next steps
+
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — write a profile from scratch before distributing it.
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — run the same profile in continuous integration.

--- a/src/app/blog/how-to-switch-environments-with-raid-env/page.mdx
+++ b/src/app/blog/how-to-switch-environments-with-raid-env/page.mdx
@@ -1,0 +1,215 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Switch Environments with raid env',
+  description:
+    'Use `raid env <name>` to switch every repo in your profile to local, staging, or production at once — variable scoping, repo overrides, and the merge rules.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'raid env', 'environment variables', 'multi-repo',
+    '.env file', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-switch-environments-with-raid-env' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+A team that ships against `local`, `staging`, and `production` ends up doing the same dance every time someone needs to switch: edit five `.env` files, run different startup commands per repo, hope nothing's stale. `raid env <name>` collapses that into one command.
+
+This guide covers how `raid env` works, where variables come from, and the merge rules between profile-level and repo-level definitions.
+
+## 1. The shape of an environment
+
+Environments are declared at the profile level. Each has a name, optional variables, and optional tasks:
+
+```yaml
+# web-platform.raid.yaml
+name: web-platform
+repositories:
+  - { name: frontend, path: ~/Developer/frontend, url: https://github.com/acme/frontend.git }
+  - { name: backend,  path: ~/Developer/backend,  url: https://github.com/acme/backend.git }
+
+environments:
+  - name: local
+    variables:
+      - { name: API_URL,  value: http://localhost:8080 }
+      - { name: NODE_ENV, value: development }
+  - name: staging
+    variables:
+      - { name: API_URL,  value: https://api.staging.acme.com }
+      - { name: NODE_ENV, value: production }
+    tasks:
+      - type: Shell
+        cmd: echo "Pointing at staging."
+```
+
+## 2. Switching environments
+
+```bash
+raid env staging
+```
+
+What happens, in order:
+
+1. Raid records `staging` as the active environment in `~/.raid/`.
+2. For every repository in the profile, Raid writes a `.env` file at the repo root containing the merged variables.
+3. Raid executes the environment's `tasks:` sequence.
+
+Every repo now has the same `.env` content, and every subsequent `raid <command>` runs against staging.
+
+## 3. Showing and listing
+
+```bash
+raid env            # show the currently active environment
+raid env list       # list every available environment
+```
+
+Both support `--json` for scriptable output — see [How to wire Raid into CI](/blog/how-to-wire-raid-into-ci).
+
+## 4. Per-repo overrides
+
+The profile defines the *shape* of the environment (which envs exist, what's globally true). Each repo can layer overrides on top in its own `raid.yaml`:
+
+```yaml
+# inside frontend's raid.yaml
+environments:
+  - name: local
+    variables:
+      - { name: PORT, value: '3000' }
+```
+
+When `raid env local` runs, the frontend repo's `.env` file gets the profile's variables plus `PORT=3000`.
+
+If both define the same key, the **repo's value wins for that key** — handy for ports, paths, or other repo-shaped values.
+
+## 5. The merge rules in one place
+
+For a given environment name, Raid loads the profile entry first and then the repo entry. The merge is conservative and predictable:
+
+| Field        | Profile + Repo behavior                                             |
+| ------------ | ------------------------------------------------------------------- |
+| `variables`  | Profile vars first, then repo vars. Repo entries override matching keys per-key. |
+| `tasks`      | Profile tasks first, then repo tasks. Both run, in that order.      |
+| `name`       | Must match exactly. Repos can't introduce new env names — only profile can. |
+
+The practical effect: profile-level changes propagate to every repo; per-repo overrides are localized. You can read any single repo's `raid.yaml` and know which values it adds on top.
+
+## 6. Common patterns
+
+### Switching the API endpoint everyone hits
+
+The classic case — one variable that needs to change across the whole stack:
+
+```yaml
+environments:
+  - name: local
+    variables: [{ name: API_URL, value: http://localhost:8080 }]
+  - name: staging
+    variables: [{ name: API_URL, value: https://api.staging.acme.com }]
+  - name: production
+    variables: [{ name: API_URL, value: https://api.acme.com }]
+```
+
+`raid env staging` and every repo's `.env` file points at staging.
+
+### Per-repo ports
+
+Each microservice listens on a different local port. Define them in each repo's `raid.yaml`:
+
+```yaml
+# auth-service/raid.yaml
+environments:
+  - name: local
+    variables: [{ name: PORT, value: '8081' }]
+```
+
+The profile's `local` env gives every repo `API_URL`; each repo's `local` env adds `PORT` on top.
+
+### Running setup tasks on switch
+
+Sometimes switching environments isn't just variables — you also need to restart a Docker network, prime a cache, or print a banner:
+
+```yaml
+environments:
+  - name: production
+    variables: [{ name: API_URL, value: https://api.acme.com }]
+    tasks:
+      - type: Print
+        message: ⚠️  You are pointed at PRODUCTION.
+        color: yellow
+      - type: Confirm
+        message: Continue?
+```
+
+Tasks run after the `.env` files are written. Combine with [Confirm tasks](/blog/how-to-use-templates-and-prompts-in-raid-tasks) for safety rails.
+
+## 7. Reading the active env from your app
+
+Each repo's `.env` file is plain `KEY=VALUE`. Use whatever your stack already uses — `dotenv` in Node, `direnv` shell loading, Go's `os.Getenv` after `godotenv.Load()`. Raid manages the file's contents; your app reads it normally.
+
+## 8. Resetting / clearing
+
+There's no explicit "no environment" mode — you switch by running a different `raid env <name>`. To re-emit the current env's `.env` files (e.g. after editing the profile), just re-run the same command:
+
+```bash
+raid env local   # rewrites every .env to match the profile + repo definition
+```
+
+## Next steps
+
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — where environments are first defined.
+- [How to Use Templates and Prompts in Raid Tasks](/blog/how-to-use-templates-and-prompts-in-raid-tasks) — for env switches that need richer flows.
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — pinning the env in non-interactive contexts.

--- a/src/app/blog/how-to-use-raid-as-an-mcp-server/page.mdx
+++ b/src/app/blog/how-to-use-raid-as-an-mcp-server/page.mdx
@@ -1,0 +1,175 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Use Raid as an MCP Server for AI Agents',
+  description:
+    'Run `raid context serve` to expose your multi-repo workspace to AI agents over MCP — six tools, six resources, JSON-RPC over stdio, no network exposure.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'MCP', 'Model Context Protocol', 'AI agent',
+    'Claude Code', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-use-raid-as-an-mcp-server' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+AI coding agents work best when they can see the *shape* of the workspace — which repos exist, what environment is active, which commands are available. Raid already knows all of that. `raid context serve` exposes it over the [Model Context Protocol](https://modelcontextprotocol.io/) so any MCP-compatible agent can read state and invoke commands directly.
+
+This guide covers what the server exposes, how to wire it into a client, and the security model.
+
+## 1. The two commands
+
+Raid ships two related entry points:
+
+- **`raid context`** — prints a one-shot snapshot of the workspace (profile, env, repos, commands, recent runs). Supports `--json`. Good for piping into any LLM context window.
+- **`raid context serve`** — runs an MCP server over stdio. The agent (Claude Code, Cursor, etc.) spawns it, speaks JSON-RPC 2.0, and can both *read* workspace state and *call* Raid actions.
+
+Same data, two access patterns: copy-paste vs. agent-driven.
+
+## 2. What the MCP server exposes
+
+The server exposes **six resources** (read-only state) and **six tools** (actions).
+
+### Resources
+
+Each resource has a `raid://` URI an MCP client can fetch:
+
+| URI                          | Content                                         |
+| ---------------------------- | ----------------------------------------------- |
+| `raid://workspace/profile`   | Active profile name (text)                      |
+| `raid://workspace/env`       | Active environment name (text)                  |
+| `raid://workspace/repos`     | Repos in the active profile + git state (JSON)  |
+| `raid://workspace/commands`  | User-defined commands available (JSON)          |
+| `raid://workspace/recent`    | Recently-run commands (JSON)                    |
+| `raid://workspace/vars`      | Persisted Raid variables (JSON, live-watched)    |
+
+### Tools
+
+Tools the agent can invoke:
+
+| Tool name              | What it does                                              |
+| ---------------------- | --------------------------------------------------------- |
+| `raid_list_profiles`   | List every registered profile                              |
+| `raid_list_repos`      | List repos in the active profile, with URLs and git state |
+| `raid_describe_repo`   | Return the parsed `raid.yaml` for a named repo            |
+| `raid_install`         | Run `raid install` (whole profile or a single repo)        |
+| `raid_env_switch`      | Switch to a named environment                              |
+| `raid_run_task`        | Execute a user-defined `raid <command>` with args         |
+
+These are the same actions you'd run from the shell — the agent just calls them as MCP tool invocations instead.
+
+## 3. Wiring it into an MCP client
+
+The server speaks JSON-RPC over stdio. A typical client configuration is just two fields:
+
+```json
+{
+  "mcpServers": {
+    "raid": {
+      "command": "raid",
+      "args": ["context", "serve"]
+    }
+  }
+}
+```
+
+For Claude Code:
+
+```bash
+claude mcp add raid -- raid context serve
+```
+
+For Cursor / Windsurf / other MCP clients, point them at the same `raid context serve` command. The exact config file location varies; the spawn line is the same.
+
+## 4. Why this is useful
+
+Concrete things an agent can do once it's wired in:
+
+- **Read repo state before suggesting an edit.** "Which branch is `frontend` on? Is it dirty?"
+- **Switch environments before a debug session.** "Set env to staging, then run the API smoke tests."
+- **Discover commands.** "Show me the commands available in this profile" — the agent reads `raid://workspace/commands` and tells you `raid test`, `raid deploy`, etc., without you copy-pasting.
+- **Invoke them with arguments.** `raid_run_task` accepts command name + args, so the agent can run `raid deploy staging` directly.
+- **Stay grounded across sessions.** When you start a new chat, the agent can re-read `raid://workspace/profile` and immediately know which project you're in.
+
+The agent gets a stable, schema'd view of the workspace instead of guessing from filenames.
+
+## 5. Security model
+
+The server is a **local process over stdio**. Practical implications:
+
+- **No network exposure.** It does not bind a port. The only way to reach it is to be the client that spawned it.
+- **No authentication.** Authentication is provided by who can spawn the process — i.e. your user account on your machine.
+- **Tool calls run with your privileges.** `raid_run_task` is the most powerful tool: anything you'd run with `raid <command>` from your shell can be triggered through it. Treat the agent that holds the connection the way you'd treat a paired-programming partner who can hit Enter on your terminal.
+- **State changes are persisted.** `raid_env_switch` and `raid_install` change the same `~/.raid/` state your CLI uses. The next time you open a shell, the env switch is still in effect.
+
+If you don't want the agent to be able to mutate state, don't wire `raid context serve` in — use one-shot `raid context --json` snapshots instead, which are strictly read-only.
+
+## 6. Snapshots without the server
+
+For agents that don't speak MCP (or sessions where you just want a context primer), pipe the snapshot in directly:
+
+```bash
+raid context --json | pbcopy   # macOS
+raid context --json             # paste into chat
+```
+
+The JSON has the same shape as the MCP resources combined — profile, env, repos, commands, recent. Drop it into your agent's system prompt or your first message.
+
+## Next steps
+
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — non-interactive flags that complement headless MCP use.
+- [Raid technical deep dive](/blog/raid-technical-deep-dive) — the design decisions behind the context model.

--- a/src/app/blog/how-to-use-templates-and-prompts-in-raid-tasks/page.mdx
+++ b/src/app/blog/how-to-use-templates-and-prompts-in-raid-tasks/page.mdx
@@ -1,0 +1,199 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Use Templates and Prompts in Raid Tasks',
+  description:
+    'Build interactive Raid workflows: collect input with Prompt and Confirm, generate files from templates with the Template task, and stay safe in headless / CI mode.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'Prompt task', 'Confirm task', 'Template task',
+    'interactive CLI', 'YAML configuration', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-use-templates-and-prompts-in-raid-tasks' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Some workflows need a human in the loop — a destructive deploy needs confirmation, a release needs a version number, a generated config needs a token. Raid's `Prompt`, `Confirm`, and `Template` task types cover those needs without dropping back to ad-hoc shell scripts.
+
+This guide walks through all three, plus how they behave in CI / headless mode.
+
+## 1. Prompt — ask for a value
+
+A `Prompt` task reads a line from stdin and stores it in a variable that later tasks can reference:
+
+```yaml
+- type: Prompt
+  var: VERSION
+  message: Version to release (e.g. 1.4.0)?
+  default: 0.0.0-dev
+```
+
+After this runs, every subsequent task in the command can use `${VERSION}` or `$VERSION` in its fields. The variable lives for the duration of the command.
+
+### Defaults
+
+`default:` serves two purposes:
+
+1. **UX**: the user can hit Enter to accept it.
+2. **Headless mode safety**: when Raid runs in non-interactive mode (`--yes`, `--headless`, `RAID_HEADLESS=1`, or `--json`), Prompt tasks use the default instead of trying to read stdin.
+
+A Prompt task **without a `default:`** in headless mode fails with the structured error `HEADLESS_PROMPT_NO_DEFAULT` and exit code 3. Always provide a default for prompts you expect to run in CI.
+
+## 2. Confirm — pause for y/yes
+
+A `Confirm` task pauses the command until the user types `y` or `yes`:
+
+```yaml
+- type: Confirm
+  message: Deploy to production?
+```
+
+Any other input — `n`, `no`, empty, Ctrl-C — fails the command. Pair Confirm with destructive operations to catch fat-fingered runs:
+
+```yaml
+- type: Print
+  message: ⚠️  This will drop the production database.
+  color: red
+- type: Confirm
+  message: Type 'yes' to continue.
+- type: Shell
+  cmd: ./scripts/drop-prod-db.sh
+```
+
+In headless mode (`--yes`, `--headless`, `RAID_HEADLESS=1`), Confirm tasks auto-accept. That's intentional — CI should never block on a prompt — but it does mean *production safety rails should not rely on Confirm alone in CI*. Add an additional gate like an explicit env var or a separate command name.
+
+## 3. Template — render a file with variables
+
+A `Template` task reads a source file, expands `$VAR` / `${VAR}` references against the current variable scope (env vars, Set/Prompt outputs), and writes the result:
+
+```yaml
+- type: Template
+  src: ./templates/local.env.tmpl
+  dest: ./.env.local
+```
+
+If `templates/local.env.tmpl` contains:
+
+```
+API_URL=${API_URL}
+DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost/dev
+VERSION=${VERSION}
+```
+
+…and `API_URL`, `DB_USER`, `DB_PASS`, `VERSION` are set in the environment or by earlier tasks, the output lands at `./.env.local` with those values substituted.
+
+Use Template for any file your app generates per-environment: config YAMLs, `.env.local`, Caddy / nginx snippets, k8s manifests for `kubectl apply`.
+
+## 4. Composing the three
+
+A common pattern: ask for a value, confirm a side effect, render a config, run it.
+
+```yaml
+commands:
+  - name: deploy
+    usage: Render the deploy manifest and apply it
+    tasks:
+      - type: Prompt
+        var: VERSION
+        message: Version to deploy (e.g. 1.4.0)?
+        default: 0.0.0-dev
+      - type: Prompt
+        var: ENVIRONMENT
+        message: Environment (staging | production)?
+        default: staging
+      - type: Print
+        message: Deploying ${VERSION} to ${ENVIRONMENT}.
+        color: cyan
+      - type: Confirm
+        message: Continue?
+      - type: Template
+        src: ./deploy/manifest.tmpl.yaml
+        dest: ./deploy/manifest.yaml
+      - type: Shell
+        cmd: kubectl apply -f ./deploy/manifest.yaml
+```
+
+Run it manually for an interactive walk-through. Run it in CI with `--yes` and explicit env vars (`RAID_VERSION=1.4.0 RAID_ENVIRONMENT=staging raid deploy --yes`) and the same tasks handle both cases.
+
+## 5. Variable sources, in priority order
+
+When Template / Shell / Set tasks expand `${VAR}`, Raid resolves the name against these sources (first match wins):
+
+1. **Variables set earlier in the same command** — via `Set` or `Prompt`.
+2. **The active environment's variables** — written to each repo's `.env`.
+3. **The process environment** — anything exported in the shell that launched `raid`.
+
+This lets you override an env-level value at runtime by setting it explicitly before the call:
+
+```bash
+API_URL=https://api.beta.acme.com raid deploy
+```
+
+## 6. CI behavior at a glance
+
+| Task     | Interactive             | Headless (`--yes` / `--headless` / `RAID_HEADLESS=1` / `--json`) |
+| -------- | ----------------------- | ---------------------------------------------------------------- |
+| Prompt   | Reads stdin             | Uses `default:`; fails `HEADLESS_PROMPT_NO_DEFAULT` if none      |
+| Confirm  | Requires `y`/`yes`       | Auto-accepts                                                     |
+| Template | Renders normally        | Renders normally (no interactivity)                              |
+
+When writing commands you expect to run in both contexts, always give Prompt tasks a `default:` — that's the single most important rule. See [How to wire Raid into CI](/blog/how-to-wire-raid-into-ci) for the full set of flags.
+
+## Next steps
+
+- [How to Define a Custom Command in Raid](/blog/how-to-define-a-custom-command-in-raid) — the broader tour of task types.
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — running interactive commands non-interactively.

--- a/src/app/blog/how-to-wire-raid-into-ci/page.mdx
+++ b/src/app/blog/how-to-wire-raid-into-ci/page.mdx
@@ -1,0 +1,217 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Tutorial',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Wire Raid into CI',
+  description:
+    'Run Raid in CI without prompts or hangs: `--yes` / `--headless` flags, `--json` output, exit-code categories, and patterns for GitHub Actions and friends.',
+  tags: ['Raid', 'Tutorial']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Raid', 'Raid CLI', 'CI', 'continuous integration', 'GitHub Actions',
+    'headless mode', 'exit codes', 'developer tooling', 'tutorial'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'TechArticle',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Tutorial',
+          about: { '@type': 'SoftwareApplication', name: 'Raid', applicationCategory: 'DeveloperApplication', url: 'https://raidcli.dev' }
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-wire-raid-into-ci' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+The same `raid <command>` your developers run locally should run unchanged in CI. The trick is silencing the prompts, structuring the output, and reading the exit code categorically. Raid has dedicated knobs for each.
+
+## 1. The flags you'll use
+
+Three global flags cover the bulk of CI use:
+
+| Flag                     | Purpose                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `--yes` / `--headless`   | Auto-resolve interactive prompts. Confirm tasks auto-accept; Prompt tasks use `default:` (or fail). |
+| `--json`                 | Emit structured JSON for commands that support it (profile/env list, doctor, context, error envelopes). |
+| `-t N` / `--threads N`   | Cap concurrent clones during `raid install`.                                    |
+
+Two environment variables that do the same job for tools that prefer env over flags:
+
+| Env var           | Effect                                                              |
+| ----------------- | ------------------------------------------------------------------- |
+| `RAID_HEADLESS=1` | Equivalent to `--yes` / `--headless`.                              |
+| `DO_NOT_TRACK=1`  | Suppresses the first-run telemetry opt-in prompt (you'd want this in CI anyway). |
+| `RAID_NO_PREFIX=1`| Drops per-task line prefixes so concurrent output stays parser-friendly. |
+
+## 2. A minimal CI step
+
+The full pattern is short:
+
+```bash
+# install raid (Linux runner)
+curl -fsSL https://raw.githubusercontent.com/8bitalex/raid/main/install.sh | bash
+
+# register the team profile
+raid profile add git@github.com:acme/raid-profiles.git
+
+# clone + bootstrap (non-interactive)
+raid install --headless
+
+# pick the env CI runs against
+raid env staging --headless
+
+# run the test command the team uses locally
+raid test --headless
+```
+
+Drop those into a GitHub Actions step, a GitLab job, or a Jenkinsfile and you've reproduced your local workflow in CI.
+
+## 3. GitHub Actions example
+
+```yaml
+name: ci
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      RAID_HEADLESS: '1'
+      DO_NOT_TRACK: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install raid
+        run: curl -fsSL https://raw.githubusercontent.com/8bitalex/raid/main/install.sh | bash
+      - name: Add profile
+        run: raid profile add ./ops/web-platform.raid.yaml
+      - name: Install
+        run: raid install
+      - name: Pick env
+        run: raid env staging
+      - name: Test
+        run: raid test
+```
+
+Setting `RAID_HEADLESS=1` at the job level means every subsequent step inherits it — no need to pass `--headless` on each call.
+
+## 4. Exit codes that mean something
+
+Raid maps failures to five categorical exit codes. CI can branch on the category instead of grep-ing log lines:
+
+| Exit code | Category   | Meaning                                                       |
+| --------- | ---------- | ------------------------------------------------------------- |
+| 1         | Generic    | Unclassified — fall-through bucket                            |
+| 2         | Config     | Invalid profile / repo schema / argument                      |
+| 3         | Task       | A user task failed (shell exit non-zero, prompt with no default, etc.) |
+| 4         | Network    | Clone failed, HTTP task failed                                |
+| 5         | Not Found  | Profile / env / command / repo missing                        |
+
+Use them to retry only transient failures (4 = network) or to short-circuit on misconfigured CI (2/5 = your YAML or env is wrong, retrying won't help):
+
+```bash
+set +e
+raid test
+case $? in
+  0) ;;
+  4) echo "Network blip — retrying once."; raid test ;;
+  *) exit 1 ;;
+esac
+```
+
+## 5. JSON output for tooling
+
+Commands that emit structured output respect `--json`:
+
+```bash
+raid profile list --json
+raid env list --json
+raid env --json            # which env is active right now
+raid context --json        # full workspace snapshot
+```
+
+Errors emit a structured envelope too:
+
+```json
+{
+  "error": {
+    "code": "PROFILE_NOT_FOUND",
+    "category": "not-found",
+    "message": "profile 'web-platform' not found",
+    "hint": "use 'raid profile list' to see available profiles"
+  }
+}
+```
+
+That's the contract a CI dashboard or a downstream tool can consume without screen-scraping.
+
+## 6. Prompts in non-interactive mode
+
+When `--headless` (or `RAID_HEADLESS=1`) is in effect, Raid resolves each interactive task as follows:
+
+- **`Confirm`** — auto-accepts. CI never blocks on a confirmation.
+- **`Prompt` with `default:`** — uses the default.
+- **`Prompt` without `default:`** — fails with code `HEADLESS_PROMPT_NO_DEFAULT` (exit 3) and a clear message naming the variable.
+
+The fix is to make every Prompt in a CI-runnable command provide a `default:`, even if the default is `''`. Or, for values that vary by run, set the variable in the shell first:
+
+```bash
+VERSION=1.4.0 raid release --headless
+```
+
+`Set` and `Prompt` look up the existing process environment when resolving the variable — explicit values in the shell take precedence over defaults.
+
+## 7. Caching the profile registration
+
+`raid profile add` writes to `~/.raid/`. In CI that directory is ephemeral, so the add cost runs each build. Two ways to skip that:
+
+- **Cache the directory.** `actions/cache` on `~/.raid` is a clean fix if your runners aren't ephemeral.
+- **Skip the registration step.** If you commit the profile inside the repo, you can pass the file path directly to `raid env` / `raid install` via `--profile` (`raid --profile ./ops/web-platform.raid.yaml install`).
+
+## Next steps
+
+- [How to Use Templates and Prompts in Raid Tasks](/blog/how-to-use-templates-and-prompts-in-raid-tasks) — defaults are the single most important rule for headless safety.
+- [How to Debug a Failing Raid Task](/blog/how-to-debug-a-failing-raid-task) — exit codes and verbose output when CI goes red.


### PR DESCRIPTION
## Summary
Medium / Baeldung-style how-to series for the Raid CLI — 13 self-contained tutorial articles, all tagged \`Raid\` + \`Tutorial\`, with the same SEO treatment as the first post in the series (TechArticle + BreadcrumbList JSON-LD, keyword-front meta description, canonical, openGraph, twitter).

Living articles — designed to be iterated as the CLI evolves.

### Onboarding & setup
- How to Add a \`raid.yaml\` to an Existing Repo
- How to Install Raid on macOS, Linux, and Windows
- How to Share a Raid Profile with Your Team

### Daily workflow
- How to Define a Custom Command in Raid
- How to Switch Environments with \`raid env\`
- How to Run Tasks in Parallel with Raid
- How to Use Templates and Prompts in Raid Tasks

### Integration
- How to Use Raid as an MCP Server for AI Agents
- How to Wire Raid into CI
- How to Migrate from Make, Taskfile, or Just to Raid

### Recipes / troubleshooting
- How to Clone All Your Team's Repos with \`raid install\`
- How to Add a Health Check to a Raid Workflow
- How to Debug a Failing Raid Task

All command behaviors, task-type names, schema fields, and exit-code categories verified against the raid source (\`src/cmd\`, \`src/internal/lib\`, \`src/raid/errs\`).

## Test plan
- [ ] \`/blog\` index lists all 13 new posts dated 2026-06-03
- [ ] \`/blog/tags/tutorial\` includes all 13 + the existing profile post
- [ ] \`/blog/tags/raid\` includes the new ones alongside design proposal + deep dive
- [ ] Cross-links between articles all resolve (no 404s)
- [ ] One sample article renders cleanly with code blocks, tables, and JSON-LD in <head>