### PR TITLE
devsite: cap home Featured Posts to the 3 newest

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default async function Home() {
 
       <AboutMe />
 
-      <FeaturedPosts posts={posts} />
+      <FeaturedPosts posts={posts.slice(0, 3)} />
 
       <Projects />
     </>


### PR DESCRIPTION
Slices `loadPosts()` to the 3 newest at the homepage call site so the Featured Posts grid stops rendering all 17 articles.