### PR TITLE
blog: 11 top-of-funnel articles (Raid, devex, AI)

### DIFF
--- a/src/app/blog/how-to-eliminate-developer-toil/page.mdx
+++ b/src/app/blog/how-to-eliminate-developer-toil/page.mdx
@@ -1,0 +1,153 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Eliminate Developer Toil on a Multi-Repo Team',
+  description:
+    "Developer toil — the manual setup, the stale wiki, the \"what's the command for that again?\" Slack thread — is fixable. Here's how to cut it systematically.",
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'developer toil', 'reduce developer toil', 'eliminate toil',
+    'engineering toil', 'developer experience', 'devex',
+    'multi-repo', 'team productivity', 'developer tooling'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-eliminate-developer-toil' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Developer toil is the work that doesn't make the product better. It's the morning rebooting docker. It's the "which port was the auth service on again?" Slack thread. It's the wiki page from 2023 that *almost* works. It's the senior engineer who has to walk every new hire through the same bootstrap. It compounds quietly — nobody calls it out as a fire, but it eats a measurable percentage of every sprint.
+
+This post is about how to fix it systematically — not via heroics, but by changing where the knowledge lives.
+
+## 1. What "toil" actually is
+
+Google's SRE book defined toil as work that's manual, repetitive, automatable, tactical, and devoid of enduring value. The same definition works for developers. A useful question: *if I quit tomorrow, would this work disappear or would the next person do it again?* If they'd do it again, it's toil.
+
+Concrete examples that show up on most multi-repo teams:
+
+- **Onboarding rituals** — clone 7 repos, follow a wiki, run a 50-line bash script, ping someone when step 4 fails because the script hasn't been updated since the prod URL changed.
+- **Environment switching** — edit `.env` files in each repo, restart the right docker services, hope the API URL got updated everywhere.
+- **Command memorization** — `npm run build` here, `make build` there, `task build` over in the new service, `just build` in the experimental one.
+- **The "actual" way to start the proxy** — exists in a Slack thread, last referenced six months ago.
+
+Each is small. Each happens hundreds of times per quarter across the team. That's the cost.
+
+## 2. Why the usual fixes don't stick
+
+Most teams have tried at least one of the following:
+
+**Wikis and READMEs.** They go stale within weeks. Nothing forces them to stay accurate, and nothing catches the drift. The fastest way to know your wiki is out of date is to onboard a new hire and watch them get stuck.
+
+**Bootstrap scripts.** Better than wikis — at least they're executable — but they live on one person's machine, drift when the process changes, and silently break in ways nobody notices until the next install. The script becomes its own toil.
+
+**Per-project task runners.** `Makefile` / `Taskfile.yml` / `justfile` solve a real problem (commands that live with the code) but only inside a single repo. As soon as your environment spans multiple repos, they don't compose.
+
+**Heroic seniors.** "Just ask Sarah." Sarah is the system. Sarah leaves.
+
+All of these are partial fixes because the *knowledge isn't versioned with the code*. It's somewhere else — a wiki, a shell history, a Slack thread, a brain.
+
+## 3. The shape of a real fix
+
+Pick a tool whose job is to keep developer commands and environments **co-located with the code, in version control, executable, and the same on every developer's machine**. That's it. Whatever you pick should satisfy:
+
+1. **One command per task.** `team test`, `team deploy`, `team env staging` — not `cd ../api && npm test && cd ../web && npm test`.
+2. **The command lives in the repo.** When the process changes, the command changes with it, in the same PR.
+3. **It works across repos.** The hard problems are at the team level, not the project level — your tool needs to know about more than one repo.
+4. **Environments are first-class.** Switching between local / staging / production should be one command, applied across every repo.
+5. **It runs the same in CI.** The thing your developers run locally is the same thing CI runs. Different invocations of the same intent are toil.
+
+The list narrows the field quickly. Most per-project task runners fail on criterion 3. Most "one-script-to-rule-them-all" approaches fail on criterion 1 (because the script grows arbitrary flags). The shape you're looking for is a *declarative, multi-repo orchestrator*.
+
+## 4. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) for exactly this. It's a small CLI that reads a YAML profile defining your team's repos, environments, and commands. The day-one onboarding flow collapses to:
+
+```bash
+brew install 8bitalex/tap/raid
+raid profile add git@github.com:acme/raid-profiles.git
+raid install                         # clones every repo, runs bootstrap
+raid env local                       # writes .env files to every repo
+raid test                            # runs the test command the team defines
+```
+
+Five commands and the new hire is running the stack. The same commands work in CI with `--headless`. When the deploy process changes, someone edits the profile in a PR — the next time the team pulls, the new behavior is just there. There's no script to maintain on one person's laptop, no wiki to rot.
+
+The mechanism isn't magic. It's that the team's workflow becomes a *versioned, reviewed, executable artifact* instead of tribal knowledge. The toil disappears because the work it represented no longer needs to happen.
+
+## 5. Three concrete moves you can make this week
+
+You don't need to adopt anything specific to start cutting toil. Three changes that pay off independently:
+
+1. **Pick one piece of tribal knowledge and check it in.** The single Slack thread everyone references. Make it a `runbook.md` in the repo, or a Taskfile recipe, or a `raid.yaml` command. Force it to live where it's reviewable.
+
+2. **Make environment switching one command.** Whatever you pick, the bar is "one command swaps every repo's `.env` and restarts the right services." If switching to staging takes more than that, fix it before doing anything else.
+
+3. **Run the next new hire through the docs without helping them.** Sit on your hands. Note every place they get stuck. Each one is toil — the wiki is wrong, the script needs an env var, the service no longer runs on port 8080. Fix the *thing*, not the wiki.
+
+## 6. Measuring whether it worked
+
+Toil is famously hard to measure, but two signals are cheap:
+
+- **Time to first commit for a new hire.** Track it. A team with sustained toil will see this number drift up over time; a team that's cut toil will see it drop and stay there.
+- **Slack questions per onboarding.** "How do I…" questions are explicit, countable signals. Drops there correlate directly with time you don't have to spend.
+
+You don't need a dashboard. You just need to notice.
+
+## Next steps
+
+- [How to Onboard a New Developer in Under an Hour](/blog/how-to-onboard-a-new-developer-fast) — the most expensive form of toil, fixed end-to-end.
+- [How to Manage Multiple Repositories Without Losing Your Mind](/blog/how-to-manage-multiple-repositories) — the multi-repo problem in detail.
+- [How to Stop Maintaining a 50-Line Bash Setup Script](/blog/how-to-stop-maintaining-a-50-line-bash-setup-script) — the specific anti-pattern most teams have.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — if Raid sounds like the right fit, this is the first step.

--- a/src/app/blog/how-to-give-your-ai-coding-agent-context-across-repos/page.mdx
+++ b/src/app/blog/how-to-give-your-ai-coding-agent-context-across-repos/page.mdx
@@ -1,0 +1,211 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Give Your AI Coding Agent Context Across Multiple Repos',
+  description:
+    "AI coding agents work much better when they can see your whole workspace. Here's how to give Claude Code, Cursor, or any MCP-compatible agent context across every repo at once.",
+  tags: ['Developer Experience', 'AI', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'AI coding agent', 'Claude Code context', 'Cursor MCP',
+    'Model Context Protocol', 'MCP server', 'AI agent multi-repo',
+    'developer tooling', 'AI workflow'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-give-your-ai-coding-agent-context-across-repos' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+AI coding agents are dramatically better when they can see the *shape* of your workspace. Which repos exist. What environment you're in. What commands the team uses. What just got run, and what failed. Most agents today work brilliantly inside one repo and get hazy as soon as you ask them anything that crosses a directory boundary.
+
+This is fixable — and it's fixable in a way that also makes the *humans* on your team more productive. The mechanism is the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP), and the trick is exposing your workspace through a small server that any MCP-aware agent can query.
+
+## 1. Why one-repo context isn't enough
+
+A typical AI coding agent today sees:
+
+- The file tree of the open project.
+- Some recent git history.
+- Whatever's in the current message.
+
+That's enough for a lot of work. It runs out when you ask:
+
+- "Which other services in the stack call this API?"
+- "Switch to staging and re-run the test."
+- "Did the deploy I asked you to run actually finish?"
+- "What's the test command for the worker service?"
+
+In all four cases, the answer lives *outside* the currently open repo. The agent doesn't know about the other repos, doesn't know about your environments, doesn't know which commands the team uses across services. It guesses, asks you, or fakes it.
+
+## 2. What MCP solves
+
+MCP is a small open protocol that lets an AI agent (Claude Code, Cursor, Windsurf, etc.) talk to a server that exposes:
+
+- **Resources** — read-only state the agent can fetch (a JSON document, a text blob).
+- **Tools** — actions the agent can invoke (run a command, fetch some data).
+
+The agent doesn't care where the server lives; it spawns a process and speaks JSON-RPC over stdio. The server can expose anything: a database, an API, a knowledge base, your workspace state.
+
+For multi-repo development, the natural resources to expose are:
+
+- The list of repos your team works on, with their git state.
+- The active environment.
+- The user-facing commands available.
+- Recently-run commands and their outcomes.
+
+And the natural tools:
+
+- Switch environments.
+- Run a command.
+- Bootstrap a repo.
+
+Once those are exposed, the agent stops guessing.
+
+## 3. The shape of a workspace MCP server
+
+A workspace MCP server doesn't need to be exotic. It needs to expose, at minimum:
+
+1. **A list of repos** — name, URL, local path, current branch, whether the working copy is dirty.
+2. **The active environment** — local / staging / production / whatever the team uses.
+3. **The available commands** — what's in `team --help`, what each does.
+4. **A way to switch environments and run commands** — the agent can act, not just observe.
+
+Pair that with **stdio-only transport** (no network exposure) and **no extra auth** (the agent is local, runs as you, can do anything you can) and you have a workable design.
+
+## 4. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this — a CLI for multi-repo orchestration with an MCP server baked in. The wiring is short:
+
+```bash
+# Add raid's MCP server to Claude Code
+claude mcp add raid -- raid context serve
+```
+
+Or in any MCP-compatible client's config:
+
+```json
+{
+  "mcpServers": {
+    "raid": {
+      "command": "raid",
+      "args": ["context", "serve"]
+    }
+  }
+}
+```
+
+Once that's in place, the agent can:
+
+- Read `raid://workspace/repos` to see every repo in the profile and its git state.
+- Read `raid://workspace/env` to know which environment is active.
+- Read `raid://workspace/commands` to see what user-defined commands exist.
+- Call `raid_env_switch` to swap environments.
+- Call `raid_run_task` to execute a team command with args.
+
+Six tools, six resources. Plenty to make the agent useful across the whole stack instead of one repo.
+
+The full how-to is in [How to use Raid as an MCP server for AI agents](/blog/how-to-use-raid-as-an-mcp-server) — including the security model.
+
+## 5. Patterns that get good results
+
+A few patterns I've found work well once the agent has workspace-level context:
+
+### "What's the shape of this codebase?"
+
+A new chat starts with the agent reading `raid://workspace/repos` and `raid://workspace/commands`. It now knows the services exist, where each lives, and what operations the team supports. Cuts down "here's the layout" preambles to zero.
+
+### "Switch to staging, run the smoke tests"
+
+The agent invokes `raid_env_switch` with `staging`, then `raid_run_task` with the smoke-test command. It can report back what passed and what failed. No copy-pasting `raid env staging && raid smoke` into the terminal yourself.
+
+### "Investigate this incident"
+
+The agent reads `raid://workspace/recent` to see what's been run lately. It correlates that with the failing service's git state. Often the cause shows up — a deploy fifteen minutes ago, a config switch this morning.
+
+### "Is this safe to run?"
+
+The agent reads the YAML for the command before running it. If it's just `npm test`, fine. If it's `kubectl delete -A`, the agent flags it instead of executing blindly. That's a property of having declarative commands the agent can *read*, not just *call*.
+
+## 6. The security model — keep it boring
+
+A few things to be deliberate about when wiring an agent to a workspace server:
+
+- **The server runs as you.** It can do anything you can do. Treat the agent connected to it the way you'd treat a paired-programming partner who can hit Enter on your terminal.
+- **State changes persist.** `raid_env_switch` changes the same `~/.raid/` state your CLI uses. The next shell you open is in the env the agent left you in.
+- **Tools can be destructive.** `raid_run_task` runs anything you've declared as a command. If you have a `raid drop-db` command in your profile (and you might, for local development), the agent can call it. Be intentional about which commands you expose, the same way you'd be intentional about a runbook.
+- **Don't expose secrets through resources.** A workspace server should expose *workspace state*, not credentials. Keep secrets in your existing secrets manager.
+
+If you want the agent to be strictly read-only, don't run the server — use `raid context --json` to dump a snapshot into the chat instead. Same data, no action surface.
+
+## 7. The collateral benefit
+
+The interesting thing is that **whatever you build to give your AI agent context turns out to be the same thing that improves your humans' experience.** A YAML profile that an MCP server reads is also a profile that:
+
+- Tells a new hire which repos exist.
+- Lets the team switch environments with one command.
+- Documents which commands the team supports.
+
+You're not building "AI infrastructure" separately. You're building developer-experience infrastructure and getting the AI integration as a side effect. That's the path of least regret on the question of how much to invest in AI-specific tooling — invest in things humans need; expose them to agents through standard protocols.
+
+## 8. Where this is heading
+
+The Model Context Protocol is young but it's moving fast. The pattern of "expose your workspace as a server" is going to be common enough within a year that not having one will feel like not having a `README.md`. The choice isn't whether to expose your workspace — it's whether you build that exposure as a one-off or as a side effect of better orchestration.
+
+The latter is the durable bet.
+
+## Next steps
+
+- [How to Use Raid as an MCP Server for AI Agents](/blog/how-to-use-raid-as-an-mcp-server) — the technical how-to.
+- [How to Manage Multiple Repositories Without Losing Your Mind](/blog/how-to-manage-multiple-repositories) — the multi-repo coordination layer that makes the AI piece useful.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — the first step.

--- a/src/app/blog/how-to-keep-dev-staging-prod-environments-in-sync/page.mdx
+++ b/src/app/blog/how-to-keep-dev-staging-prod-environments-in-sync/page.mdx
@@ -1,0 +1,196 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Keep Dev, Staging, and Prod Environments in Sync',
+  description:
+    'Environment drift is the silent cause of "passed in staging, failed in prod" incidents. Here\'s a model for keeping them in sync without a config-management framework.',
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'environment parity', 'dev prod parity', 'environment management',
+    'environment drift', 'staging vs production', 'twelve factor app',
+    '.env files', 'developer experience'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-keep-dev-staging-prod-environments-in-sync' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+"Worked in staging, failed in production" is a pattern, not an accident. It happens because **staging and production are configured separately**, by different people, at different times, with no single artifact that says what's different and why. The values drift, and the drift surfaces as incidents.
+
+Same problem, smaller blast radius: "worked on my machine, failed in CI." Same root cause. Same fix.
+
+This post is about a low-overhead model for keeping environments in sync — without adopting a heavyweight config-management framework.
+
+## 1. What "in sync" actually means
+
+It does not mean "identical." A production environment will always differ from local: real secrets, real domains, real scale. The thing you actually want is **structural parity** — the *set of variables*, the *shape of the deployment*, the *startup sequence* are the same. Only the values change.
+
+A useful test: can you write down, in one screen, every variable your application reads from its environment? If yes, you're in good shape regardless of where the values come from. If no — if it's spread across five `.env.example` files, three Terraform modules, and the build pipeline — you have drift waiting to happen.
+
+## 2. Where drift comes from
+
+The usual suspects:
+
+- **Per-repo `.env.example` files** that fall out of date because nobody owns them.
+- **Environment-specific code paths** (`if NODE_ENV === 'production'`) that turn the environment into part of the program logic rather than an input.
+- **Secrets management that's separate from config management.** The secret rotation in prod doesn't get reflected in the `.env.example` developers copy from.
+- **CI configuration that drifts independently.** A pipeline that exports `API_URL` at run time instead of reading from the same definition the developer uses.
+- **No single switch.** Changing from local to staging requires editing N `.env` files in N repos, and nobody updates all of them.
+
+Each is fixable in isolation. None of them get fixed when "fixing it" requires going through five different review processes.
+
+## 3. The model: one definition, three values
+
+Whatever tool you pick, the model that works is:
+
+- **One file defines the variables your app reads.** This is the source of truth for what variables exist.
+- **One file per environment defines values.** Local, staging, prod each get their own value sheet. Same keys, different values.
+- **One command switches between them.** Editing five `.env` files by hand is where drift comes from; one command that writes them from the source-of-truth is where it stops.
+
+The shape is identical to twelve-factor's "store config in the environment," with one addition: a tool above the `.env` files that knows what each environment should contain.
+
+## 4. Implementation in three takes
+
+### Take 1: Shell scripts
+
+```bash
+# scripts/env.sh
+case "$1" in
+  local)   API_URL=http://localhost:8080 ;;
+  staging) API_URL=https://api.staging.acme.com ;;
+  prod)    API_URL=https://api.acme.com ;;
+esac
+echo "API_URL=$API_URL" > .env
+```
+
+Works for one repo. Fails as soon as you have several repos, because you need to apply the same env switch to all of them. Now you're maintaining N scripts that have to agree.
+
+### Take 2: Per-environment files
+
+```
+repo-a/.env.local
+repo-a/.env.staging
+repo-a/.env.production
+repo-b/.env.local
+repo-b/.env.staging
+repo-b/.env.production
+...
+```
+
+Better. The values are explicit. The downside: a value that appears in every repo (`API_URL`) needs to be updated in N×3 files when it changes. The drift surface area gets larger, not smaller.
+
+### Take 3: A profile-level definition
+
+A team-wide YAML file declares environments and variables at the *fleet* level. A small CLI reads it and writes the right `.env` to each repo when you switch:
+
+```yaml
+# acme.raid.yaml
+environments:
+  - name: local
+    variables:
+      - { name: API_URL, value: http://localhost:8080 }
+      - { name: LOG_LEVEL, value: debug }
+  - name: staging
+    variables:
+      - { name: API_URL, value: https://api.staging.acme.com }
+      - { name: LOG_LEVEL, value: info }
+  - name: production
+    variables:
+      - { name: API_URL, value: https://api.acme.com }
+      - { name: LOG_LEVEL, value: warn }
+```
+
+```bash
+team env staging
+```
+
+That writes the staging values into every repo's `.env`. There's one source of truth. The PR that adds a new variable is the one that propagates it to every environment. Drift becomes structurally impossible.
+
+For per-repo additions (like a service's own port), the repo gets its own small config that *adds* keys on top — but only in addition, never in conflict.
+
+## 5. The secret problem
+
+The above gets you structural parity. It does *not* get you secrets management — and you should not put real secrets in plain YAML, even encrypted. Pair the env switcher with whatever your team already uses for secrets:
+
+- **Cloud KMS / SOPS / age-encrypted files** for medium-sensitivity values.
+- **Vault / 1Password / Doppler** for proper secrets.
+- **Kubernetes Secrets / SSM Parameter Store** in deployed environments.
+
+The model is: the env switcher writes everything *except* secrets to the `.env` file. Secrets get injected at runtime by your secrets tool. The variable *exists* in the definition (so devs know it's there), but its value comes from a different source.
+
+## 6. CI is just another environment
+
+Most teams treat CI as a separate problem from local development. It doesn't have to be. If `team env staging` is what writes a developer's `.env` file, the same command can run in CI to produce CI's `.env`. The bootstrap-the-environment artifact is the same. Drift between local and CI is impossible by construction.
+
+If you're at the point where you're writing a separate "what CI exports" config, you've already broken parity. Pull it back into the same definition.
+
+## 7. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this model. The profile defines environments; `raid env <name>` writes per-repo `.env` files; the same command runs in CI as locally. The full how-to is in [How to switch environments with `raid env`](/blog/how-to-switch-environments-with-raid-env).
+
+You don't have to use Raid. The point is that **the source-of-truth shape — one definition, one switch command, same artifact local and CI — is what makes parity tractable**. Pick any tool that fits that shape.
+
+## 8. How you know it's working
+
+Two signals:
+
+- **The "what changed?" question after a prod incident has a precise answer.** When something works in staging and fails in prod, the answer is in the env definition — go look at the file. If you can't say what differs from a single source, you don't have parity.
+- **Adding a new variable is one PR.** Touches the env definition, gets reviewed, propagates. If adding a new variable means "update the wiki, update five `.env.example` files, update the CI config, update Terraform" — you're a long way from parity.
+
+## Next steps
+
+- [How to Switch Environments with `raid env`](/blog/how-to-switch-environments-with-raid-env) — the mechanism in detail.
+- [How to Make "It Works on My Machine" Actually Mean Something](/blog/how-to-make-it-works-on-my-machine-mean-something) — the developer-local version of the same problem.
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader problem this fits inside.

--- a/src/app/blog/how-to-make-it-works-on-my-machine-mean-something/page.mdx
+++ b/src/app/blog/how-to-make-it-works-on-my-machine-mean-something/page.mdx
@@ -1,0 +1,166 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Make "It Works on My Machine" Actually Mean Something',
+  description:
+    "The phrase is a meme because it's almost never true. Here's how to make local development environments consistent enough that 'works on my machine' becomes a real signal.",
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'works on my machine', 'environment parity', 'developer environment',
+    'reproducible builds', 'dev environment consistency',
+    'twelve factor app', 'developer experience'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-make-it-works-on-my-machine-mean-something' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+"It works on my machine" became a meme because it's almost always *false* in a useful sense. Sure, the test passes on the developer's laptop — but their laptop has a different Node version, the wrong `.env`, a cached docker image, and a half-finished migration the rest of the team doesn't have. Of course it works on their machine. That's not a signal.
+
+Making the phrase mean something requires that "my machine" and "anyone else's machine" be *structurally identical* — same dependencies, same versions, same environment, same data shape. When that's true, "it works on my machine" becomes solid evidence that the change is correct. When it's not, "it works on my machine" is at best a starting point.
+
+This post is about how to close the gap.
+
+## 1. What's actually different between machines
+
+The honest list of things that drift between developer laptops:
+
+- **Language toolchain versions.** Node 18 vs Node 22; Go 1.21 vs 1.23; the wrong Python venv.
+- **System tools.** `make` vs `gmake`. `gnu-sed` vs BSD `sed`. `jq` 1.6 vs 1.7. (macOS users especially feel this.)
+- **Docker image cache.** Two developers' `node:20-alpine` may be built three weeks apart, with different OS-level packages.
+- **Local environment variables.** Different `API_URL`, different `LOG_LEVEL`, different feature flags.
+- **Local data.** A database seeded last quarter vs. one seeded yesterday.
+- **Untracked config files.** Someone's `.envrc` includes a debug flag. Someone's `direnv` is loading something the other isn't.
+- **Local edits to dependencies.** A `node_modules` patch that survived an `npm ci` because the cache was warm.
+
+Each of these is benign in isolation. Together they make "it works on my machine" a probabilistic statement, not an evidentiary one.
+
+## 2. The two strategies (and their limits)
+
+There are two broad approaches to closing the gap.
+
+**Strategy A: Containerize everything.** Run all development inside Docker. Dev containers in VS Code. devcontainers.json. The promise: the container has fixed versions, fixed system tools, fixed everything.
+
+The cost is real: container-based dev has performance penalties (especially on macOS where file system syncing is famously imperfect), IDE integration trade-offs, and a learning curve that's not zero. Done well, it pretty much eliminates drift. Done halfway, it adds a new source of drift (different host configs, different container caches, different mount strategies).
+
+**Strategy B: Standardize the host setup.** Pin language versions with `asdf` / `mise` / `nvm`. Pin system tools with Homebrew Bundle / nix. Pin environment variables with a team-level definition. Pin data with reproducible seeds.
+
+Lighter weight. Slower to actually achieve full parity (because the host is still hers, not a container). But the day-to-day developer experience is closer to "just code."
+
+Most teams end up with **Strategy B with selective containerization** — host-pinned toolchains for fast dev iteration, Docker for backing services (Postgres, Redis, the message bus), and CI uses the same Docker images as local for its services.
+
+## 3. The pieces that make Strategy B work
+
+If you're going the host-pinned route, the components you need:
+
+1. **Pinned language versions.** `.tool-versions` (asdf/mise) committed in the repo. Everyone gets the same Node/Go/Python/Ruby.
+2. **Pinned system tools.** A `Brewfile` or equivalent that's part of the bootstrap. Not optional — if `jq` is required, it's installed by the bootstrap, not by tribal knowledge.
+3. **Pinned environment variables.** A team-level definition (not five `.env.example` files) that the bootstrap writes to each repo. See [How to keep dev / staging / prod environments in sync](/blog/how-to-keep-dev-staging-prod-environments-in-sync).
+4. **Reproducible local data.** A `seed.sh` that drops and recreates the local DB from a known state. Pair with a `team reset` command that runs it.
+5. **Containerized backing services.** Postgres, Redis, etc. in Docker. The same images locally and in CI.
+6. **One command that wires it all together.** A bootstrap step that pins, installs, seeds, and writes config in one pass.
+
+Each piece is well-trodden in isolation. The team-level coordination is what's missing in most setups.
+
+## 4. The forgotten lever: the bootstrap *itself*
+
+What unlocks all of this is that **the bootstrap is a versioned artifact**. Not a script on one engineer's laptop. Not a wiki page. A YAML file (or equivalent) checked in to source control, reviewed in PRs, and run by every developer the same way.
+
+When the team rolls out a new tool (Postgres 17 → 18, Node 22 → 24), it's one PR to the bootstrap. Everyone's next pull picks it up. There's no drift period where some developers have the new version and some don't — the bootstrap is the source of truth.
+
+This is what makes "it works on my machine" useful: every machine ran the same bootstrap. The differences are now real, not artifacts of drift.
+
+## 5. What this looks like in practice
+
+A team-level YAML profile defines the install steps for the whole stack:
+
+```yaml
+install:
+  tasks:
+    - { type: Shell, cmd: brew bundle --file=./Brewfile }
+    - { type: Shell, cmd: asdf install }
+    - { type: Shell, cmd: docker compose -f ./infra/local.yml up -d }
+    - { type: Wait,  url: localhost:5432, timeout: 60s }
+    - { type: Shell, cmd: ./scripts/seed.sh }
+```
+
+Each repo's `raid.yaml` adds its own per-repo steps (`npm ci`, `go mod download`, codegen). One command runs the whole thing:
+
+```bash
+raid install
+```
+
+Every developer's machine, every CI run — same bootstrap. When something diverges, the bootstrap is where you go to fix it, and the fix propagates to everyone.
+
+I built [Raid](https://github.com/8bitAlex/raid) for this. You don't have to use Raid — the property that matters is that the bootstrap is versioned, declarative, and the same artifact everywhere.
+
+## 6. What changes when this works
+
+A few quiet but important changes happen when the bootstrap is solid:
+
+- **`team reset` becomes routine.** When everything is reproducible, "blow away my env and restart" is a 5-minute operation, not a half-day. Developers run it casually.
+- **Bug reports are higher-quality.** When the developer's environment is known, "I see X" tells you more than when their setup is a snowflake.
+- **CI failures are diagnosable locally.** If CI is reproducible from the same bootstrap you ran, you can usually reproduce a CI failure on your laptop in a couple of commands.
+- **"Works on my machine" actually starts to mean something.** It's a claim that the change is correct *in a known environment*, which is the strongest local signal you can produce.
+
+## 7. The diminishing returns warning
+
+You can spend a quarter chasing exact-bit parity between local and CI. Don't. The point isn't bitwise identical environments — it's that the *axes of difference* are explicit and small. Aim for "if it works on my machine, it'll work in CI 95% of the time." That's a vast improvement over the baseline. The last 5% is a separate, expensive project.
+
+## Next steps
+
+- [How to Keep Dev, Staging, and Prod Environments in Sync](/blog/how-to-keep-dev-staging-prod-environments-in-sync) — the same problem at production scale.
+- [How to Stop Maintaining a 50-Line Bash Setup Script](/blog/how-to-stop-maintaining-a-50-line-bash-setup-script) — the specific artifact most teams need to retire.
+- [How to Clone All Your Team's Repos with `raid install`](/blog/how-to-clone-all-your-team-repos-with-raid-install) — the bootstrap primitive.

--- a/src/app/blog/how-to-manage-multiple-repositories/page.mdx
+++ b/src/app/blog/how-to-manage-multiple-repositories/page.mdx
@@ -1,0 +1,197 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Manage Multiple Repositories Without Losing Your Mind',
+  description:
+    'Multi-repo (polyrepo) development gets a bad reputation it doesn\'t deserve. The problem isn\'t the repos — it\'s the lack of a layer above them. Here\'s the layer.',
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'multi-repo', 'polyrepo', 'multiple repositories', 'managing many repositories',
+    'monorepo alternative', 'developer experience', 'devex', 'multi-repo orchestration'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-manage-multiple-repositories' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Multi-repo development gets blamed for a lot of problems it doesn't actually cause. Slow onboarding, drift between services, inconsistent tooling — these aren't symptoms of *having* many repos. They're symptoms of having no layer that knows about all of them at once.
+
+This post is about what that layer is, what it should do, and why the monorepo-vs-polyrepo debate misses the point.
+
+## 1. What multi-repo is bad at
+
+The honest list:
+
+- **No single command to clone everything.** You're chasing a wiki for which repos to pull.
+- **Per-project task runners don't compose.** `make build` in repo A and `task build` in repo B and a Compose file in repo C.
+- **Environment switching is N commands, not one.** Each repo has its own `.env`; switching to staging means editing all of them.
+- **Cross-repo refactors are expensive.** Search-replace across N working copies, N PRs, N reviews.
+- **Onboarding takes forever.** New hires walk a wiki for a day to set up a local environment that worked on day zero of the codebase.
+
+Real problems. Worth taking seriously.
+
+## 2. What monorepos are *also* bad at
+
+The teams that switch to a monorepo to fix the above often discover a new set of problems:
+
+- **Build tooling becomes a research project.** Bazel, Pants, Nx — each has a learning curve measured in months.
+- **Per-team autonomy decreases.** Everyone is now coupled to the build graph, the CI pipeline, the release cadence.
+- **CI gets expensive.** Naive setups rebuild the world on every change; sophisticated setups require sophisticated remote-cache infrastructure.
+- **Permissions get awkward.** Open-sourcing one component, granting a contractor access to one service, splitting off an experimental project — all harder.
+- **History rewrites get scary.** When the repo is 20 million lines, even routine operations get heavy.
+
+Both shapes have real trade-offs. The "monorepo solves everything" pitch is overblown, and the "polyrepo is a mess" pitch is too.
+
+## 3. What's actually missing in most polyrepo setups
+
+The polyrepo problems above share a common ancestor: **there's no tool that holds the team's mental model of "all our repos and how they work together."** Each repo has its own README, its own Makefile, its own bootstrap script. The team-level view exists only in people's heads.
+
+The fix isn't to switch to a monorepo. It's to add the missing layer.
+
+You want a tool that:
+
+1. Knows the **list of repositories** your team works on, where each one lives on disk, and how to clone each.
+2. Defines **named environments** (local / staging / production) that apply across every repo at once.
+3. Exposes **commands** that work no matter which repo you're standing in — `team test`, `team deploy`, `team format`.
+4. **Merges per-repo configuration** (commands and env that are specific to one service) with the team-level configuration above.
+5. Lives **in version control** as plain config, not as someone's bash script.
+
+That's the gap. Fill it and almost every polyrepo complaint goes away.
+
+## 4. What the team-level layer looks like
+
+Concretely, the layer is a YAML file that describes the system:
+
+```yaml
+name: web-platform
+repositories:
+  - { name: frontend, path: ~/Developer/frontend, url: https://github.com/acme/frontend.git }
+  - { name: api,      path: ~/Developer/api,      url: https://github.com/acme/api.git }
+  - { name: worker,   path: ~/Developer/worker,   url: https://github.com/acme/worker.git }
+
+environments:
+  - name: local
+    variables:
+      - { name: API_URL, value: http://localhost:8080 }
+  - name: staging
+    variables:
+      - { name: API_URL, value: https://api.staging.acme.com }
+
+commands:
+  - name: format
+    tasks:
+      - { type: Shell, cmd: make format, path: ~/Developer/frontend, concurrent: true }
+      - { type: Shell, cmd: make format, path: ~/Developer/api,      concurrent: true }
+      - { type: Shell, cmd: make format, path: ~/Developer/worker }
+```
+
+That's a definition of the team's whole environment. From it, a tool can:
+
+- Clone every repo in one command.
+- Switch every repo's environment with one command.
+- Run cross-repo commands in parallel.
+- Tell a new hire what commands exist (`tool --help`).
+- Tell an AI agent what the workspace looks like.
+
+Each repo can still have its own `Makefile`, its own `Taskfile.yml`, its own `package.json`. The team-level layer doesn't replace per-project tooling — it sits above it.
+
+## 5. Per-repo overrides
+
+The other half of the model is that each repo can commit its own configuration file alongside the code. That's where repo-specific commands and environment overrides live:
+
+```yaml
+# inside frontend/raid.yaml
+name: frontend
+commands:
+  - { name: dev, tasks: [{ type: Shell, cmd: npm run dev }] }
+environments:
+  - { name: local, variables: [{ name: PORT, value: '3000' }] }
+```
+
+The team-level profile gives every repo `API_URL`. The frontend's `raid.yaml` adds `PORT=3000` on top — visible only inside that repo, but managed by the same tool.
+
+The split works because:
+- **Team-level stuff scales horizontally.** Adding a new repo is one entry in the profile.
+- **Repo-level stuff stays local.** A change to one service's commands only touches that service's `raid.yaml`.
+- **Both live in source control.** The PR that introduces a new command is the same one that documents and ships it.
+
+## 6. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this model: a YAML profile at the team level, a `raid.yaml` in each repo, a CLI that merges them at runtime. The team's workflow becomes:
+
+```bash
+raid install       # clone every repo + run install tasks
+raid env staging   # swap every .env, run env tasks
+raid test          # run the team's test command across the right repos
+raid deploy        # run the team's deploy command
+```
+
+That's not specific to Raid — pick any tool that fits the shape above. The point is that multi-repo development is fine *once you stop treating the repos as the unit of organization* and start treating the team's workflow as the unit. The repos are an implementation detail.
+
+## 7. When to actually go monorepo
+
+To be fair: there are real cases where a monorepo is the right answer. If you have:
+
+- Frequent cross-repo refactors that benefit from atomic commits.
+- A small enough codebase that build tooling stays simple.
+- A homogeneous tech stack (all Go, all JS) where one build tool can own everything.
+
+…then a monorepo can save you real time. The decision is engineering taste, not a moral one. But the choice should be informed by *what problem you're actually trying to solve*. Most "we should go monorepo" arguments are really "our multi-repo workflow has no team-level layer" — and the team-level layer is a much cheaper fix.
+
+## Next steps
+
+- [Monorepo vs Polyrepo: A Third Option for the Developer Experience](/blog/monorepo-vs-polyrepo-a-third-option) — the longer version of the debate framing.
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader problem this fits inside.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — concrete first step if Raid sounds like the right shape.

--- a/src/app/blog/how-to-onboard-a-new-developer-fast/page.mdx
+++ b/src/app/blog/how-to-onboard-a-new-developer-fast/page.mdx
@@ -1,0 +1,173 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Onboard a New Developer in Under an Hour',
+  description:
+    'Most engineering onboarding takes days. It doesn\'t have to. Here\'s the shape of an onboarding flow where a new hire is running the stack and making commits the same morning.',
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'developer onboarding', 'engineering onboarding', 'new hire onboarding',
+    'onboarding checklist', 'time to first commit', 'developer experience',
+    'devex', 'team productivity'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-onboard-a-new-developer-fast' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+There's a number you can use to grade your engineering team's developer experience: **time to first commit**. How long from "laptop opened on day one" to "first PR merged"? Most teams report somewhere between two days and two weeks. Most teams could honestly hit one hour. The gap is almost entirely process, not engineering.
+
+This post is about closing that gap — what a sub-hour onboarding looks like, why most teams fall short, and the architectural decisions that make the difference.
+
+## 1. Why onboarding takes so long
+
+Walk through the typical first-day arc on a multi-repo team:
+
+1. Install local tooling (homebrew packages, language toolchains, Docker).
+2. Clone 5–10 repos from the team.
+3. Read a wiki to learn the bootstrap order.
+4. Run setup scripts that may or may not still work.
+5. Edit `.env` files in each repo to match the local environment.
+6. Start backing services (Postgres, Redis, the message bus).
+7. Run migrations and seed data.
+8. Figure out which command starts the dev server in each repo.
+9. Read the README of the repo you're about to work in.
+10. Find the issue you're assigned and start coding.
+
+If everything works on the first try, that's maybe four hours. Anything wrong with step 3, 4, 5, 6, or 7 — and there usually is — and you're easily into day two or three. Multiply by the number of new hires per quarter.
+
+The waste compounds. Two engineers will be tied up walking them through the script that broke. The wiki page gets a tiny edit that someone else will trip over later. The bootstrap becomes more fragile, not less.
+
+## 2. What a fast onboarding actually looks like
+
+The end state is short:
+
+```
+09:00  laptop open, IDE installed
+09:05  install the team CLI tool
+09:10  add the team profile / clone all repos
+09:25  bootstrap finishes; local environment is up
+09:30  walk through the codebase with a buddy for context
+10:00  first PR merged
+```
+
+The technical part is twenty-five minutes. The remaining time is the social part — meeting the team, getting context — which is the part that actually deserves the hours.
+
+The shape of that flow has three properties worth naming:
+
+- **One command per step.** Not "install X, then Y, then run script Z." One command does the entire bootstrap.
+- **No wikis in the critical path.** The instructions are an executable artifact, not a document. If the artifact's wrong, the next install fails loudly — which gets it fixed.
+- **The same flow runs in CI.** Whatever bootstraps the new hire's laptop is the same thing CI runs. Drift between local and CI is impossible by construction.
+
+## 3. What's actually in the way
+
+The reasons most teams' onboarding takes two days reduce to a small set of root causes:
+
+**The bootstrap lives in tribal knowledge.** "Talk to Sarah, she'll get you set up" is a code smell. It means the system is in a person, not in code.
+
+**Per-project tooling doesn't compose.** `make build` in repo A and `task build` in repo B and a Compose file in repo C means three things to learn before you can run the stack.
+
+**Environments are configured by hand.** Each repo's `.env` is hand-edited. Each new repo adds another step the bootstrap needs to remember.
+
+**The fix is a one-off script.** Someone wrote `setup.sh` on their machine. It works on their machine. It will continue to work, until it doesn't, and then it will rot quietly.
+
+None of these are individually catastrophic. Together they make a two-hour problem into a two-day problem.
+
+## 4. The architectural pieces of a one-hour onboarding
+
+What you're really building is a **runnable definition of the developer environment**. The pieces:
+
+1. **A version-controlled file describing the environment.** Which repos exist, where they live on disk, what environments are supported, what commands the team uses. Plain YAML works; the format matters less than the property of being a single source of truth.
+2. **A single tool that reads it.** Installs in one command, idempotent, the same on every developer's machine. Probably a Go binary or a static install script — anything that doesn't drag in language-version drama.
+3. **One bootstrap command** that clones every repo and runs each repo's install steps in the right order.
+4. **One environment-switch command** that writes per-repo `.env` files and runs any setup tasks for that environment.
+5. **First-class commands** so the team's commands (`team test`, `team deploy`) are discoverable in `--help`, not scattered across READMEs.
+
+That's the architecture. It's not exotic; it's just a discipline.
+
+## 5. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this shape — it's a CLI that reads a YAML profile defining your team's repos, environments, and commands. The bootstrap flow is the five commands above:
+
+```bash
+brew install 8bitalex/tap/raid
+raid profile add git@github.com:acme/raid-profiles.git
+raid install
+raid env local
+raid test
+```
+
+That's a sub-hour onboarding on a real multi-repo stack. The same commands work in CI, so the bootstrap that produced the new hire's local environment is the same one CI runs every PR.
+
+The point isn't that you have to use Raid. The point is that whatever tool you pick, the *shape* — one declarative file, one tool, one bootstrap command, one env switch — is what gets you under an hour. Everything else is detail.
+
+## 6. What to measure
+
+Two numbers tell you whether you've actually closed the gap:
+
+- **Time to first commit.** Start the clock when the laptop opens. Stop it when their first PR is merged. Most teams have never measured this; almost everyone is shocked by the actual number.
+- **Onboarding questions per new hire.** Count the Slack DMs your senior engineers get from a new hire in week one. If it's high, your "executable bootstrap" isn't actually executable end-to-end. Fix the gaps.
+
+## 7. The follow-on effect
+
+The hidden benefit isn't only for new hires. Every existing engineer who switches machines, blows away their environment because something broke, or pulls down a service they haven't touched in a year goes through the same flow. A one-hour onboarding for new hires is also a one-hour "rebuild my dev environment" for everyone.
+
+That's the part you actually feel quarter over quarter.
+
+## Next steps
+
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader problem this fits inside.
+- [How to Clone All Your Team's Repos with `raid install`](/blog/how-to-clone-all-your-team-repos-with-raid-install) — the bootstrap command in detail.
+- [How to Share a Raid Profile with Your Team](/blog/how-to-share-a-raid-profile-with-your-team) — distributing the profile so the onboarding flow above works.

--- a/src/app/blog/how-to-stop-maintaining-a-50-line-bash-setup-script/page.mdx
+++ b/src/app/blog/how-to-stop-maintaining-a-50-line-bash-setup-script/page.mdx
@@ -1,0 +1,173 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Stop Maintaining a 50-Line Bash Setup Script',
+  description:
+    'Every team has the script. It works until it doesn\'t. Here\'s how to replace `setup.sh` with something the team can actually rely on — without rewriting your tools.',
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'bootstrap script', 'developer setup script', 'setup.sh',
+    'developer environment', 'shell script', 'developer experience',
+    'devex', 'developer onboarding'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-stop-maintaining-a-50-line-bash-setup-script' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Every long-lived engineering team has the same artifact. It's called `setup.sh`, or `bootstrap.sh`, or `dev-env.sh`. It started as fifteen lines that one engineer wrote on a Friday. Now it's 187 lines, has cross-platform `if [ "$(uname)" = "Darwin" ]` branches in three places, calls a Python script that calls a Ruby script, and exactly one person knows what step 4 actually does.
+
+This is a love letter to that script — and a guide to retiring it.
+
+## 1. Why the script exists
+
+It's not stupid. Every line in `setup.sh` got added for a reason. Someone hit a problem; this fixed it; they committed the fix; someone else picked it up. The script is a fossil record of the team's onboarding pain. That's actually good — it means the pain is *somewhere*, not just in people's heads.
+
+But the script has structural problems no amount of refactoring fixes:
+
+- **It lives in one repo.** If your team has multiple repos, the script is in the "main" one — leaving the others to fend for themselves with READMEs.
+- **It hides its dependencies.** What needs to be installed before `setup.sh` will run? You find out by running it and watching it fail.
+- **It's not idempotent.** Re-running it after a partial failure is a coin flip.
+- **It mixes concerns.** Installing tools, cloning repos, writing config, running migrations, starting services — all interleaved.
+- **It has no clear notion of "environment."** Switching from local to staging is a different code path that mostly didn't get tested.
+- **It can't be inspected without running it.** The README says "run setup.sh." That's not documentation.
+
+It worked for the team's first dozen developers. It's groaning under the next dozen.
+
+## 2. What you actually want instead
+
+The replacement doesn't have to be exotic. The properties you want:
+
+1. **Declarative, not procedural.** A list of *what* the bootstrap does, not *how*. Easier to read, easier to review, easier to skip steps that already ran.
+2. **Idempotent.** Running it twice in a row does the same thing as running it once.
+3. **Inspectable.** You can see what it'll do before it does it.
+4. **Cross-platform without ifs.** The runner handles macOS vs Linux vs Windows; your config doesn't.
+5. **Decomposed.** Cloning a repo and running its install steps are separate phases, not interleaved.
+6. **The same in CI as locally.** No `if [ -z "$CI" ]` branches.
+
+The shape that satisfies all six is a *task runner that reads a config file*, not a shell script.
+
+## 3. The "just use Make" objection
+
+`Make` covers a lot of this. So does `Taskfile`. So does `Just`. They are all real improvements over a shell script — they're declarative, they're inspectable, they're decomposed.
+
+What they don't cover:
+
+- **Multi-repo.** A Makefile lives in one repo. If your bootstrap clones N repos and runs N install steps, you need either N Makefiles (and the discipline to keep them aligned) or one Makefile that knows about all the repos (and now you're back to a setup.sh in YAML form).
+- **Environment switching across repos.** Same problem in a different shape.
+- **Cross-repo commands.** "Run lint across every repo" needs the top-level something.
+
+For a single repo's bootstrap, Make / Taskfile / Just are entirely sufficient. The case for something different starts when your environment spans multiple repos.
+
+## 4. What the replacement looks like
+
+A team-level YAML file describes the system: repos, environments, commands. A small CLI reads it and does the bootstrap:
+
+```yaml
+name: web-platform
+repositories:
+  - { name: api,      path: ~/Developer/api,      url: https://github.com/acme/api.git }
+  - { name: frontend, path: ~/Developer/frontend, url: https://github.com/acme/frontend.git }
+
+install:
+  tasks:
+    - { type: Shell, cmd: 'docker compose -f ./infra/local.yml up -d' }
+    - { type: Wait,  url: localhost:5432, timeout: 60s }
+    - { type: Shell, cmd: ./scripts/migrate.sh }
+    - { type: Shell, cmd: ./scripts/seed.sh }
+```
+
+Plus each repo can commit its own install steps in a `raid.yaml`:
+
+```yaml
+# api/raid.yaml
+install:
+  tasks:
+    - { type: Shell, cmd: go mod download }
+    - { type: Shell, cmd: go generate ./... }
+```
+
+`raid install` walks all of it in the right order. No bash, no `uname` branches, no "did this step run already?" — the runner handles it.
+
+## 5. The transition: don't rewrite, wrap
+
+The mistake teams make when retiring `setup.sh` is rewriting every line. Don't. The shell logic in your script is mostly correct — it's been debugged over years. Wrap it instead.
+
+A reasonable migration:
+
+1. **Start a new config alongside the script** (`raid.yaml`, `Taskfile.yml`, whatever you pick). Don't delete `setup.sh` yet.
+2. **Have the new config call existing script chunks.** A single `Shell` task that runs `./setup.sh --step bootstrap-db` is fine for now.
+3. **Migrate pieces one at a time.** Move "clone repos" into the runner's clone primitive. Move "wait for Postgres" into a `Wait` task. Move "run migrations" into a `Shell` task that calls the existing migration script.
+4. **Once the runner is doing everything, retire `setup.sh`.** By this point it's a thin wrapper around primitives the runner already understands.
+
+The script can coexist with the new tool for a quarter. Eventually everyone uses the new tool, and the script can be deleted in one PR.
+
+## 6. The replacement isn't a config-management framework
+
+To be clear: this *isn't* Chef / Puppet / Ansible / Pulumi. Those tools are for managing servers. The thing you're replacing `setup.sh` with is a *developer-environment task runner* — much lighter, much more local, much more concerned with "did the dev's machine just bootstrap correctly?" than with "is server X in compliance state Y?"
+
+Don't reach for a heavyweight config-management tool here. The bar is "small CLI + YAML file." Anything more is overkill.
+
+## 7. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this shape — a small Go binary that reads a YAML profile and replaces the pile-of-bash with a declarative bootstrap. The full onboarding command becomes `raid install`, the env switch is `raid env local`, and CI runs the same thing your developers do.
+
+You don't have to use Raid. The point is that **`setup.sh` is a symptom**, not a solution. The real problem is that the team's bootstrap isn't versioned, declarative, or inspectable. Replace those three properties with anything you like.
+
+## Next steps
+
+- [How to Add a `raid.yaml` to an Existing Repo](/blog/how-to-add-a-raid-yaml-to-an-existing-repo) — start small with one repo's bootstrap.
+- [How to Clone All Your Team's Repos with `raid install`](/blog/how-to-clone-all-your-team-repos-with-raid-install) — the multi-repo install primitive.
+- [How to Migrate from Make, Taskfile, or Just to Raid](/blog/how-to-migrate-from-make-taskfile-just-to-raid) — wrapping existing tooling, not replacing it.

--- a/src/app/blog/how-to-write-a-runbook-your-team-actually-follows/page.mdx
+++ b/src/app/blog/how-to-write-a-runbook-your-team-actually-follows/page.mdx
@@ -1,0 +1,201 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'How to Write a Runbook Your Team Actually Follows',
+  description:
+    "Most runbooks rot the day after they're written. The fix isn't a better wiki — it's making the runbook executable and version-controlled so the team can't ignore it.",
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'runbook', 'runbooks', 'team runbook', 'operational runbook',
+    'engineering documentation', 'incident response', 'developer experience'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/how-to-write-a-runbook-your-team-actually-follows' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+A runbook is supposed to be the document you reach for at 3 AM when something's broken. In practice, most runbooks are the document you find at 3 AM, discover is six months out of date, and abandon to go ping the on-call engineer who actually knows what to do.
+
+This post is about how to write runbooks that don't rot — and the realization that what most teams call "runbooks" should actually be **executable artifacts**, not documents.
+
+## 1. The runbook trap
+
+The standard runbook lives in a wiki. It has sections like "Deploying the API," "Rotating a credential," "Recovering from a stuck migration." Each section is prose with embedded commands.
+
+The trap is that **prose can be wrong silently**. The command that was `kubectl rollout restart deployment api` last quarter is now `kubectl rollout restart deployment api-v2`, and the only person who knows is the engineer who renamed it. The wiki still says the old thing. Anyone who runs it gets a confusing "no such resource" error and falls back to asking the on-call.
+
+The problem isn't that wiki editors are lazy. The problem is that **the runbook isn't load-bearing**. Nobody runs the wiki page; people run the *commands* it documents. When the commands change, nothing forces the wiki to keep up.
+
+## 2. What "executable runbook" means
+
+Replace the prose with code. Not a 200-line bash script — a small declarative file that lists the steps:
+
+```yaml
+commands:
+  - name: deploy-api
+    usage: Deploy the api service to staging
+    tasks:
+      - { type: Confirm, message: "Deploying api to staging — continue?" }
+      - { type: Shell, cmd: kubectl --context staging rollout restart deployment api }
+      - { type: Wait,  url: https://api.staging.acme.com/health, timeout: 120s }
+      - { type: Print, message: "api is healthy in staging.", color: green }
+```
+
+That's the runbook. Anyone runs `team deploy-api`. The steps are explicit, reviewed in PRs, and impossible to silently drift — when somebody renames the deployment, this file fails immediately, and the fix is in the same PR as the rename.
+
+The wiki, if you keep one, becomes a thin layer of context — *why* the steps exist, *who* owns them — not a list of commands.
+
+## 3. The five rules of a runbook that doesn't rot
+
+Concretely, what makes one version durable and another version rot:
+
+**Rule 1: The runbook is the executable, not the description.** Prose around the executable is fine — sometimes essential. But the commands themselves should be the source of truth, not transcribed into prose.
+
+**Rule 2: It lives in the repo, not the wiki.** The PR that changes the deploy process should change the runbook in the same commit. If they live in different systems, they drift.
+
+**Rule 3: It's reviewed.** A runbook change is a code change. It gets a PR. Two eyes. Tests if appropriate.
+
+**Rule 4: It's idempotent where possible.** Running it twice in a row should do roughly the same thing as running it once. If it can't be (a one-way migration), the runbook should *fail safely* on re-run, not corrupt state.
+
+**Rule 5: It's the same artifact in incident response, scheduled work, and CI.** "Deploying" is one operation, regardless of who's invoking it. If you have one deploy procedure for incidents and another for normal deploys, the incident one will drift.
+
+## 4. What this looks like in practice
+
+A few concrete patterns:
+
+### Deploy runbook
+
+```yaml
+commands:
+  - name: deploy
+    usage: Deploy the active service to the target environment
+    tasks:
+      - { type: Prompt, var: TARGET, message: "Environment (staging | production)?", default: staging }
+      - { type: Confirm, message: "Deploy to ${TARGET}?" }
+      - { type: Shell,  cmd: "./scripts/deploy.sh ${TARGET}" }
+      - { type: Wait,   url: "https://api.${TARGET}.acme.com/health", timeout: 120s }
+      - { type: Print,  message: "Deployed to ${TARGET}.", color: green }
+```
+
+### Credential rotation runbook
+
+```yaml
+commands:
+  - name: rotate-db-password
+    usage: Rotate the DB password and roll it through the apps
+    tasks:
+      - { type: Print, message: "Rotating database password — apps will restart.", color: yellow }
+      - { type: Confirm, message: "Continue?" }
+      - { type: Shell, cmd: "./scripts/rotate-secret.sh DB_PASSWORD" }
+      - { type: Shell, cmd: "kubectl rollout restart deployment api" }
+      - { type: Wait,  url: "https://api.acme.com/health", timeout: 120s }
+      - { type: Print, message: "Rotation complete.", color: green }
+```
+
+### Incident-response runbook
+
+```yaml
+commands:
+  - name: incident-restart-worker
+    usage: Restart the worker if jobs are backlogged
+    tasks:
+      - { type: Shell, cmd: kubectl rollout restart deployment worker }
+      - { type: Wait,  url: http://worker.internal/health, timeout: 60s }
+      - { type: Shell, cmd: kubectl logs -l app=worker --tail=50 }
+```
+
+That's three runbooks, three operations, each version-controlled. A new on-call engineer's runbook training is `team --help` — they get the full list of operations and can read the YAML to see what each does.
+
+## 5. What goes in the wiki vs. what goes in the runbook
+
+You probably still want a wiki. The split that works:
+
+- **Wiki:** *why* a thing matters. Architectural context. Decision rationale. Incident postmortems. Onboarding orientation. Anything that explains the *system* rather than describes how to *operate* it.
+- **Runbook (executable):** *how* to do each operation. Commands. Sequencing. Pre- and post-flight checks.
+
+A wiki page about "the auth subsystem" is great. A wiki page titled "Deploying auth" is a smell — that should be `team deploy-auth`.
+
+## 6. The handoff: from script to runbook
+
+Most teams that try to retire their wiki runbooks fail because they try to rewrite everything. Don't. Migrate one operation at a time:
+
+1. Pick a single procedure — usually deploy, because everyone runs it and the wiki version is most likely wrong.
+2. Move it into the runner. The first version can be a single `Shell` task that calls the existing script. That's fine.
+3. Use it for a week. Edit it when reality diverges from what's there.
+4. Once it's stable, delete the wiki version (or leave a stub pointing at the runner command).
+5. Pick the next procedure.
+
+After a quarter you've migrated the top 10 operations the team actually runs. The wiki has gotten lighter, not heavier. The runbooks are the source of truth because they're the *only thing that runs*.
+
+## 7. The team-level view
+
+The thing that takes this from "nice scripts" to "actual runbook infrastructure" is making the operations *discoverable* without a wiki. `team --help` should list every operation the team supports. New on-calls should be able to grep through the runbook directory to find what they need. No memorized URLs to the wiki, no asking in Slack.
+
+I built [Raid](https://github.com/8bitAlex/raid) around exactly this — declarative YAML commands at the team and per-repo level, all surfaced through one CLI. Whatever tool you pick, the bar is "every team operation is one command, defined in source control, discoverable through `--help`."
+
+## 8. The on-call test
+
+Easy way to measure if your runbooks work: hand them to a new on-call engineer who's never run any of them. Can they do the operation without paging someone senior?
+
+If yes — your runbooks are load-bearing.
+If no — your runbooks are aspirational documents.
+
+The point of all of the above is moving from the second to the first.
+
+## Next steps
+
+- [How to Define a Custom Command in Raid](/blog/how-to-define-a-custom-command-in-raid) — the mechanism that makes runbooks executable.
+- [How to Wire Raid into CI](/blog/how-to-wire-raid-into-ci) — running the same runbooks non-interactively.
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader picture.

--- a/src/app/blog/make-vs-taskfile-vs-just-vs-raid/page.mdx
+++ b/src/app/blog/make-vs-taskfile-vs-just-vs-raid/page.mdx
@@ -1,0 +1,193 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'Make vs Taskfile vs Just vs Raid: Picking a Task Runner in 2026',
+  description:
+    'Make, Taskfile, Just, and Raid each solve different problems. Here\'s an honest comparison — what each is best at, where each falls short, and how to pick.',
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'Make vs Taskfile', 'Taskfile vs Just', 'Just vs Make',
+    'task runner comparison', 'developer tooling 2026',
+    'Makefile alternative', 'task automation', 'developer experience'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/make-vs-taskfile-vs-just-vs-raid' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+Picking a task runner in 2026 is less straightforward than it used to be. Make is universally available and universally hated. Taskfile is great YAML and a smaller community. Just is fast and ergonomic but Linux-flavored. Raid is the newest, and it solves a different problem from the other three.
+
+Disclosure: I wrote Raid. I'll try to be fair to the others — they all earned their place — but my bias is real. The comparison below tries to be honest about where each shines and where each falls short, including Raid.
+
+## 1. The TL;DR
+
+| Tool      | Best at                                        | Falls short on                                  |
+| --------- | ---------------------------------------------- | ----------------------------------------------- |
+| Make      | Single-project builds, universal availability  | Readable YAML, multi-repo, cross-platform polish |
+| Taskfile  | YAML readability, single-project orchestration | Multi-repo, environment-switching                |
+| Just      | Ergonomics, fast, command-as-recipe model      | YAML purity, multi-repo, broad Windows support  |
+| Raid      | Multi-repo orchestration, environments         | Standalone single-project use cases             |
+
+If you have **one repo**, Make / Taskfile / Just are all reasonable; pick on syntactic taste. If you have **multiple repos** and a team, Raid is the answer.
+
+## 2. Make
+
+The default. Available everywhere. The syntax dates from the 1970s and has the wisdom and the warts of that age — tabs vs spaces, recursive Makefile pitfalls, the quirky way variables expand.
+
+**Where it shines.** Make is *everywhere*. Every CI runner has it. Every developer recognizes `make build`. For a single-project repo where you want zero install friction, Make is hard to beat.
+
+**Where it falls short.** Multi-project orchestration is painful (recursive make is famously fragile). The syntax is hostile to YAML-trained eyes. Cross-platform behavior between GNU Make on Linux and BSD Make on macOS is a tax. Self-documenting `make help` requires conventions, not native support.
+
+**Pick Make when:** you have one repo, you don't want to introduce a new tool, and your team is comfortable with the syntax.
+
+## 3. Taskfile
+
+A YAML task runner inspired by `make` but reimagined for the modern era. Single Go binary, cross-platform, readable YAML, includes, dependencies, dynamic variables.
+
+**Where it shines.** Taskfile is the cleanest YAML task runner in active development. It has real features (deps, includes, sources/generates for incremental work, dynamic vars). It's pleasant to write and pleasant to read. Cross-platform behavior is consistent.
+
+**Where it falls short.** Like Make, it's project-scoped. If you have five repos, you have five Taskfiles, and keeping them aligned is manual. Environment switching across repos isn't a built-in concept. Per-team distribution (an `acme/raid-profiles`-style repo) doesn't have a Taskfile equivalent.
+
+**Pick Taskfile when:** you have one repo and want better Make. Or you have a few repos that don't need cross-repo coordination.
+
+## 4. Just
+
+A command runner inspired by Make, written in Rust, with a focus on ergonomics. The `justfile` reads cleanly, the CLI is fast, and the recipes-as-shell-functions model is elegant.
+
+**Where it shines.** Just is delightful to use for a single repo. The `just --list` output is the cleanest of any tool here. Recipe parameters, dependencies, and `set` directives are well-designed. It's fast.
+
+**Where it falls short.** The DSL isn't YAML, which some teams prefer for schema validation and editor completion. Windows support exists but isn't as polished as Linux/macOS. Same multi-repo limit as Make and Taskfile — Just is project-scoped.
+
+**Pick Just when:** you have one repo, you want the nicest single-project task runner, and your team is comfortable adding a (small) new tool to their PATH.
+
+## 5. Raid
+
+A multi-repo orchestrator. Where Make/Taskfile/Just live inside a single repo, Raid lives at the *team* level — a YAML profile declares which repos exist, what environments are supported, and what commands the team runs. The CLI clones repos, switches environments, and runs commands across the whole workspace.
+
+**Where it shines.** Anything that crosses repo boundaries. Day-one onboarding (`raid install` clones every repo). Environment switching (`raid env staging` writes `.env` to every repo). Cross-repo commands (`raid test` runs the team's test command across services). Distribution to a team (point everyone at a Git URL containing the profile).
+
+**Where it falls short.** Raid isn't trying to be your single-project build tool. It does have an 11-task-type runner that *could* handle single-project orchestration, but in practice you'll keep using Make/Taskfile/Just for the per-project work and have Raid wrap them at the team level.
+
+**Pick Raid when:** you have multiple repos and a team. Or you're tired of maintaining a 50-line bash bootstrap script.
+
+## 6. The shape that matters
+
+A useful way to think about the choice:
+
+- **Per-project task runners** (Make, Taskfile, Just) solve the question "how does our team run commands in this one project?"
+- **Multi-repo orchestrators** (Raid) solve the question "how does our team run commands across this collection of projects?"
+
+They're not really competitors. They compose. The teams I've seen succeed at multi-repo developer experience tend to have *both* — `make` / `task` / `just` in each repo for language-specific work, and Raid at the team level wrapping them with a consistent CLI.
+
+Concrete shape:
+
+```yaml
+# raid.yaml in each repo wraps the per-project runner
+commands:
+  - { name: build, tasks: [{ type: Shell, cmd: make build }] }
+  - { name: test,  tasks: [{ type: Shell, cmd: make test }] }
+```
+
+```yaml
+# team profile defines cross-repo operations
+commands:
+  - name: test-all
+    tasks:
+      - { type: Shell, cmd: make test, path: ~/Developer/api,      concurrent: true }
+      - { type: Shell, cmd: make test, path: ~/Developer/frontend, concurrent: true }
+```
+
+The team's existing Make / Taskfile / Just investment isn't wasted. Raid wraps it.
+
+## 7. The honest "don't use Raid" cases
+
+To make this an actually-fair comparison, here are cases where Raid is the wrong pick:
+
+- **Single repo, no team coordination.** Use Make/Taskfile/Just. Raid is overkill.
+- **You don't run more than one service locally.** The multi-repo features are the value. If you have one service, you don't need them.
+- **You've already invested heavily in Nx / Turborepo for a monorepo.** Those tools occupy a similar coordination layer for monorepos. Don't add a second one.
+- **You want hermetic incremental builds.** Raid's task runner doesn't track inputs/outputs for caching. Bazel/Nx do that better for builds-as-graphs.
+
+For everything else — and especially for the polyrepo-with-a-team case — Raid is the simplest tool that solves the multi-repo coordination problem.
+
+## 8. A migration that doesn't blow up the team
+
+If you're considering Raid and you've already got Make/Taskfile/Just, the migration isn't a rewrite:
+
+1. **Keep your existing per-project tooling.** It works. Don't touch it.
+2. **Add `raid.yaml` to each repo** with commands that shell out to your existing recipes.
+3. **Add a team-level profile** with repos, environments, and any cross-repo commands.
+4. **Roll out to the team gradually.** Developers can install Raid when they're ready. Old workflows still work.
+
+No flag day, no rewrite mandate. See [How to migrate from Make, Taskfile, or Just to Raid](/blog/how-to-migrate-from-make-taskfile-just-to-raid) for the longer version.
+
+## 9. Quick decision matrix
+
+If your dominant pain is...
+
+- **The Make syntax is hostile** → Taskfile or Just.
+- **My team's CLI is inconsistent across services** → Raid wraps existing recipes.
+- **Onboarding takes 2+ days** → Raid (clones, bootstraps, env-switches in one command).
+- **Switching from local to staging is N manual steps** → Raid (`raid env staging`).
+- **CI does something different from what developers run** → Pick anything declarative; the win is "same artifact local and CI." Make/Taskfile/Just give you that within a project; Raid gives you that across projects.
+- **My single-repo Makefile works fine** → Don't change it.
+
+The honest answer for most teams is "you already have Make/Taskfile/Just doing the per-project layer; add a multi-repo orchestrator above it." Raid is one option for that layer.
+
+## Next steps
+
+- [How to Migrate from Make, Taskfile, or Just to Raid](/blog/how-to-migrate-from-make-taskfile-just-to-raid) — concrete migration recipes.
+- [How to Define a Custom Command in Raid](/blog/how-to-define-a-custom-command-in-raid) — Raid's task model in detail.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — first step if Raid sounds right.

--- a/src/app/blog/monorepo-vs-polyrepo-a-third-option/page.mdx
+++ b/src/app/blog/monorepo-vs-polyrepo-a-third-option/page.mdx
@@ -1,0 +1,184 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'Monorepo vs Polyrepo: A Third Option for the Developer Experience',
+  description:
+    "The monorepo-vs-polyrepo debate frames the wrong axis. Most teams don't actually need to pick — they need a layer above their repos that handles team-level orchestration.",
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'monorepo vs polyrepo', 'monorepo', 'polyrepo', 'multi-repo',
+    'monorepo alternative', 'codebase architecture', 'developer experience',
+    'nx', 'bazel', 'turborepo'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/monorepo-vs-polyrepo-a-third-option' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+The monorepo-vs-polyrepo debate has been running for a decade. By now most teams have an instinct about which side they're on, and both sides are wrong in interesting ways.
+
+The actual question isn't *how many repos do we have*. It's *how does our developer experience scale with the number of services we run*. And it turns out that question can be answered well in either repo shape — if you do one specific thing.
+
+This post is about that specific thing.
+
+## 1. The debate as it's usually framed
+
+The standard pros and cons, briefly:
+
+**Monorepo wins on:** atomic cross-cutting changes, easy shared code, uniform tooling, "everything builds together."
+**Monorepo loses on:** build-tool complexity (Bazel/Pants/Nx have real learning curves), CI cost (clever caching or expensive rebuilds), per-team autonomy, history rewrites at scale.
+
+**Polyrepo wins on:** independence between teams, smaller blast radius for changes, simpler per-project tooling, easier open-sourcing.
+**Polyrepo loses on:** coordinating changes across services, harder onboarding (multiple repos to clone, multiple `.env` files), "wait, which command starts the API in this one?"
+
+Both lists are real. Both shapes are workable. Most teams pick based on which set of pains they've felt most recently. Then they spend a year discovering the other set.
+
+## 2. The thing both shapes need
+
+Squint at the polyrepo pain list. Almost every entry is some flavor of: **there's no single tool that knows about all the services at once**. Onboarding is hard because no tool clones everything. Switching environments is hard because no tool edits every `.env`. Running commands is hard because no tool knows which repo to run them in.
+
+Now squint at the monorepo wins. Atomic cross-cutting changes? Uniform tooling? "Everything builds together"? Those are the *byproducts* of having a single thing that knows about all the code at once. The thing happens to be a giant repo, but the *property* — one tool, whole-system view — is what's actually doing the work.
+
+The third option is to **get the property without the giant repo**: a tool that knows about all your services, lives at the team level, and works whether your code is in one repo or twenty.
+
+## 3. What that looks like
+
+The tool is small. It reads a YAML file that lists your services, where each lives, what environments are supported, and what commands the team runs:
+
+```yaml
+name: web-platform
+repositories:
+  - { name: frontend, path: ~/Developer/frontend, url: https://github.com/acme/frontend.git }
+  - { name: api,      path: ~/Developer/api,      url: https://github.com/acme/api.git }
+  - { name: worker,   path: ~/Developer/worker,   url: https://github.com/acme/worker.git }
+
+environments:
+  - name: local
+    variables: [{ name: API_URL, value: http://localhost:8080 }]
+  - name: staging
+    variables: [{ name: API_URL, value: https://api.staging.acme.com }]
+
+commands:
+  - name: test
+    tasks:
+      - { type: Shell, cmd: npm test, path: ~/Developer/frontend, concurrent: true }
+      - { type: Shell, cmd: go test ./..., path: ~/Developer/api, concurrent: true }
+```
+
+From there, the team-level operations work the way they would in a monorepo:
+
+```bash
+team install    # clones everything, runs install steps
+team env local  # writes .env to every repo
+team test       # runs the test command across services in parallel
+team deploy     # one deploy command, however the team defines it
+```
+
+Each repo can still have its own `package.json` / `go.mod` / `Cargo.toml`. Each repo can still own its own release cadence. Each repo still has its own CI. The polyrepo *autonomy* survives. The monorepo *team-level operations* show up anyway.
+
+## 4. Why this works
+
+The reason both shapes feel painful is the same: the *unit of organization* is the repo, but the *unit of work* is usually the team. When the units don't match, you get coordination overhead — meetings, wikis, scripts, tribal knowledge.
+
+A team-level orchestrator changes the unit of organization to the *team's workspace*. The repos become an implementation detail. You can have one of them, you can have twenty, the operations look the same from the outside.
+
+The monorepo is one way to achieve this. It collapses the implementation detail to a single repo, at the cost of needing serious build tooling. The team-level orchestrator is another way: it leaves the repos alone and adds a thin coordination layer.
+
+For most teams the orchestrator is cheaper. You're not rewriting your build system. You're not migrating millions of lines of history. You're adding one YAML file and one CLI.
+
+## 5. When the monorepo is actually right
+
+To be fair: monorepos do solve some problems orchestrators can't.
+
+- **Truly atomic cross-cutting refactors.** If you rename a function across 50 services, one PR in a monorepo beats 50 PRs across separate repos.
+- **Tight shared-code coupling.** Internal libraries used by every service can avoid the publish-version-update dance.
+- **Strict commit ordering across services.** "The API change goes live with the frontend change" is structurally guaranteed.
+
+If these are the *main* problems you have, a monorepo with mature build tooling is probably the right answer. Be honest about whether they're your main problems — most teams discover their main problems were really about coordination overhead, which the orchestrator fixes more cheaply.
+
+## 6. When polyrepo is actually right
+
+The opposite case:
+
+- **Independent release cadences across teams.** Each team owns when their service ships.
+- **Different tech stacks per service.** Go here, TypeScript there, Rust over there — no single build system fits all of them.
+- **Open-sourcing some services.** Hard to do from inside a monorepo.
+- **Permissions per service.** Some teams have access to some services and not others.
+
+These are situations where the monorepo's collapse-everything-to-one-repo doesn't help, and the polyrepo's independence is structurally useful. Add a team-level orchestrator and you keep all of that *and* get the team-level operations.
+
+## 7. The honest selection process
+
+If you're trying to make the call, the question to start with is **what specific pain are you trying to solve?**
+
+- "Onboarding takes too long" → orchestrator.
+- "Env switching is N commands" → orchestrator.
+- "Cross-repo refactors are expensive" → monorepo *might* be right, but verify by counting how many cross-repo refactors you actually do.
+- "Different teams can't move at their own speed" → polyrepo + orchestrator.
+- "Our build tooling per service is great, our team coordination is bad" → orchestrator over your existing polyrepo.
+
+The number of teams that genuinely need the *commit-level atomicity* of a monorepo is small. The number of teams that would benefit from team-level operations over their repos is large. Pick honestly.
+
+## 8. What this looks like in practice
+
+I built [Raid](https://github.com/8bitAlex/raid) as the team-level orchestrator for polyrepo setups. The full how-to is in the [Raid tutorial series](/blog/tags/raid). The point isn't that you have to use Raid — it's that the *shape* (small CLI, YAML profile, team-level operations) is the third option that the monorepo-vs-polyrepo debate has been missing.
+
+You don't have to pick. You can have small repos, autonomous teams, and team-level operations all at once.
+
+## Next steps
+
+- [How to Manage Multiple Repositories Without Losing Your Mind](/blog/how-to-manage-multiple-repositories) — the polyrepo pain list in detail.
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader picture this fits inside.
+- [How to Create a Raid Profile](/blog/how-to-create-a-raid-profile) — concrete first step if the orchestrator shape sounds right.

--- a/src/app/blog/why-your-developer-setup-is-slow/page.mdx
+++ b/src/app/blog/why-your-developer-setup-is-slow/page.mdx
@@ -1,0 +1,172 @@
+import { BlogPost } from '@/lib/mdx.ts'
+import { faGears } from '@fortawesome/free-solid-svg-icons'
+
+export const post = {
+  ...BlogPost,
+  type: 'Article',
+  icon: faGears,
+  date: '2026-06-03',
+  title: 'Why Your Developer Setup Is Slow (and How to Fix It)',
+  description:
+    "Slow developer setup is rarely about hardware. It's almost always about coordination overhead — and it has a recognizable shape that's worth diagnosing before throwing tools at it.",
+  tags: ['Developer Experience', 'Raid']
+}
+
+export const metadata = {
+  title: post.title,
+  description: post.description,
+  keywords: [
+    'slow developer setup', 'developer environment setup', 'devex',
+    'developer productivity', 'engineering productivity',
+    'time to first commit', 'developer experience'
+  ],
+  alternates: { canonical: 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow' },
+  openGraph: {
+    type: 'article',
+    url: 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow',
+    title: post.title,
+    description: post.description,
+    siteName: 'Alex Salerno',
+    publishedTime: post.date,
+    authors: [post.author.name],
+    tags: post.tags
+  },
+  twitter: { card: 'summary_large_image', title: post.title, description: post.description }
+}
+
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Article',
+          '@id': 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow#article',
+          headline: post.title,
+          description: post.description,
+          datePublished: post.date,
+          dateModified: post.date,
+          inLanguage: 'en',
+          url: 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow',
+          mainEntityOfPage: { '@type': 'WebPage', '@id': 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow' },
+          author: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          publisher: { '@type': 'Person', name: post.author.name, url: 'https://www.alexsalerno.dev' },
+          articleSection: 'Developer Experience'
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.alexsalerno.dev' },
+            { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://www.alexsalerno.dev/blog' },
+            { '@type': 'ListItem', position: 3, name: post.title, item: 'https://www.alexsalerno.dev/blog/why-your-developer-setup-is-slow' }
+          ]
+        }
+      ]
+    })
+  }}
+/>
+
+When a team complains that "setting up the dev environment is slow," the first instinct is usually to buy faster laptops. Sometimes that helps. Almost always it papers over the actual problem: the bottleneck isn't compute, it's coordination.
+
+This post is for the tech lead or engineering manager who keeps hearing about onboarding pain and wants a clear-eyed read on where the time actually goes — and a sense of what's worth fixing.
+
+## 1. Where the hours go
+
+Run an honest accounting on the next new hire. Walk through onboarding behind them with a stopwatch. The hours typically break down something like this:
+
+- **5–10%** — installing language toolchains and Docker. Real work, not really fixable.
+- **10–15%** — actually cloning repositories and running their install steps. Real work, mostly idle network time.
+- **20–30%** — reading the wiki. Or worse, finding *which* wiki page is current.
+- **20–30%** — running into a script that doesn't work and waiting for someone senior to debug it.
+- **10–20%** — `.env` files: which one to copy from, which values to change, which secrets to ask for.
+- **10–20%** — "huh, that's weird, let me ask in #engineering."
+
+The first two are the actual cost of getting the environment ready. The other 80% is coordination overhead — the new hire is blocked on someone else's attention or on documentation that drifted.
+
+The size of the coordination overhead is the size of the problem. Hardware is almost never the right knob.
+
+## 2. The shape of slow setup
+
+Five recognizable symptoms. If you see most of them, you have a "process" problem, not a "performance" problem:
+
+- **Senior engineers spend hours on every onboarding.** This is the most expensive form of toil — you're paying twice for the same install.
+- **The bootstrap is documented in a wiki that's older than the youngest service.** A wiki that points at a script that no longer exists is the canonical version of this.
+- **New hires hit something that "should work" but doesn't.** Usually a Docker image that drifted, a port that changed, a service that got renamed.
+- **The team has a private Slack channel just for "have you set up X yet?" questions.** Or worse, the public channel is full of them and senior people quietly turn off notifications.
+- **The "how to set up the local environment" runbook hasn't been opened since the new hire opened it.** Documentation that's only read, never written, is documentation that's wrong.
+
+If you have three or more of these, the setup isn't slow because of hardware. It's slow because the workflow is uncodified.
+
+## 3. Why this happens (and keeps happening)
+
+The reasons are structural, not personal. A few:
+
+**The bootstrap was built for one developer.** Day zero of the project, one engineer wrote setup.sh. It worked for them. Every subsequent developer either followed it (and it almost worked) or didn't (and figured something out). The set of "how to get this working" forks across the team.
+
+**Documentation has no enforcement.** A wiki page is a write-once artifact unless someone is explicitly responsible for keeping it current. They're not. So it rots.
+
+**The team's process changed faster than the wiki.** Three services got renamed, two ports moved, one deploy pipeline got rewritten. None of those PRs included updates to the onboarding doc.
+
+**No one wants to be the "process person."** Updating the wiki feels low-status. Real engineering is shipping code. The wiki rots predictably as a result.
+
+The fix is to make the setup *itself* the documentation. If "how to onboard" is an executable, version-controlled artifact, the PR that changes the deploy process is the PR that changes the bootstrap. The wiki problem disappears not because someone finally maintained the wiki, but because there isn't a wiki anymore.
+
+## 4. The actual fix
+
+You're looking for these properties in whatever tool you pick:
+
+1. **Bootstrap lives in source control,** in a format you can review like code.
+2. **It's executable,** not prose — running it is the only way to know it works.
+3. **It's idempotent,** so re-running it after a partial failure isn't scary.
+4. **It works the same across macOS / Linux / Windows,** because your team has all three.
+5. **It's the same artifact CI uses,** so drift between local and CI is impossible.
+6. **It knows about every repo,** not just the one it lives in.
+
+Make + a script gets you 1, 2, 3, partially 4, sometimes 5, almost never 6. Taskfile/Just are similar — strictly better than a shell script, but not great at the multi-repo case. The shape that nails all six is a *declarative multi-repo orchestrator*.
+
+The specific tool matters less than the shape. The shape is what kills the onboarding tax.
+
+## 5. What this looks like in practice
+
+A team that has the shape right has an onboarding sequence that fits on a postcard:
+
+```bash
+# Day one, 9am
+brew install <team-tool>            # or curl ... | sh on Linux
+<team-tool> add <team-config>       # registers the team profile
+<team-tool> install                 # clones everything, runs install
+<team-tool> env local               # sets the env across every repo
+<team-tool> test                    # runs the team's test command
+```
+
+If you can produce a sequence like that for your team, you've fixed it. The exact tool — I built [Raid](https://github.com/8bitAlex/raid) for this; you might prefer something else — is detail.
+
+If you can't, the next step is figuring out which property above is missing. You can usually nail it down in one afternoon of walking the latest new hire's onboarding with them.
+
+## 6. What to push back on
+
+A few things that look like fixes but aren't:
+
+- **"Let's buy everyone M4 MacBooks."** Hardware doesn't fix coordination. (Get good hardware anyway — but for the right reason.)
+- **"Let's rewrite the wiki."** The wiki rots again in three months. The artifact that doesn't rot is executable and reviewed.
+- **"Let's hire a DevEx engineer."** A person can hold the system together for a while. But unless they ship a *tool* the team uses, the toil comes back when they leave.
+- **"Let's move to a monorepo."** Sometimes the right answer; usually not. See [How to manage multiple repositories without losing your mind](/blog/how-to-manage-multiple-repositories) for when it actually applies.
+
+The cheapest fix is changing where the bootstrap *lives*, not what it's written in. Move it from wiki + scripts + tribal knowledge into a single version-controlled artifact and the slowness mostly goes away.
+
+## 7. The case to make to your team
+
+If you're trying to get buy-in for fixing this, the numbers are usually compelling:
+
+- Two days of onboarding × four new hires per quarter × $80/hr ≈ **$5,000 of new-hire time per quarter.**
+- Add the senior engineers debugging it (an hour each on average) ≈ **another $2,000+.**
+- Multiply by N quarters until somebody fixes it.
+
+Most fixes pay for themselves before the next new hire starts.
+
+## Next steps
+
+- [How to Onboard a New Developer in Under an Hour](/blog/how-to-onboard-a-new-developer-fast) — the concrete target.
+- [How to Stop Maintaining a 50-Line Bash Setup Script](/blog/how-to-stop-maintaining-a-50-line-bash-setup-script) — the specific artifact most teams need to retire.
+- [How to Eliminate Developer Toil on a Multi-Repo Team](/blog/how-to-eliminate-developer-toil) — the broader category this fits inside.


### PR DESCRIPTION
## Summary
Top-of-funnel companion to the Raid tutorial series — 11 articles targeting pain-point search intent from people who don't know Raid exists yet. Each leads with the problem, walks partial solutions and their limits, then introduces Raid as a fitting answer (soft sell, not a pitch).

Tagged \`Developer Experience\` + \`Raid\` (one also \`AI\`). Same SEO treatment as the tutorial series.

### Engineering pain
- How to Eliminate Developer Toil on a Multi-Repo Team
- How to Onboard a New Developer in Under an Hour
- How to Manage Multiple Repositories Without Losing Your Mind
- How to Keep Dev, Staging, and Prod Environments in Sync
- How to Stop Maintaining a 50-Line Bash Setup Script

### Process / team pain
- Why Your Developer Setup Is Slow (and How to Fix It)
- How to Write a Runbook Your Team Actually Follows
- How to Make \"It Works on My Machine\" Actually Mean Something

### Comparison / decision
- Monorepo vs Polyrepo: A Third Option for the Developer Experience
- Make vs Taskfile vs Just vs Raid: Picking a Task Runner in 2026

### AI / agent angle
- How to Give Your AI Coding Agent Context Across Multiple Repos

Articles cross-link into the existing how-to series for concrete next steps. Living documents.

## Test plan
- [ ] \`/blog\` index shows the 3 newest (cap from PR #132 in effect)
- [ ] \`/blog/tags/developer-experience\` tag page renders with all 11
- [ ] \`/blog/tags/raid\` includes the new ones alongside the tutorial series
- [ ] \`/blog/tags/ai\` renders with the one AI-tagged post
- [ ] Cross-links between articles all resolve