### PR TITLE
devsite: add "See all posts" CTA under home Blog Posts section

### DIFF
--- a/src/components/sections/FeaturedPosts.tsx
+++ b/src/components/sections/FeaturedPosts.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/Button'
 import { FadeIn, FadeInStagger } from '@/components/FadeIn'
 import Section from '@/components/layout/Section'
 import { MDXEntry, Post } from '@/lib/mdx'
@@ -42,6 +43,9 @@ export default function FeaturedPosts({ posts }: { posts: Array<MDXEntry<Post>> 
             </FadeIn>
           ))}
         </FadeInStagger>
+        <FadeIn className="mt-12 flex justify-center">
+          <Button href="/blog">See all posts</Button>
+        </FadeIn>
       </Section>
       <QuoteBanner author={{ name: 'Antoine de Saint-Exupéry' }} className="mt-8 mb-16">
         Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away.

--- a/src/test/integration/FeaturedPosts.test.tsx
+++ b/src/test/integration/FeaturedPosts.test.tsx
@@ -53,8 +53,14 @@ describe('FeaturedPosts', () => {
 
   it('post article links to post href', () => {
     render(<FeaturedPosts posts={[makePost({ href: '/blog/my-post' })]} />)
-    const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('href', '/blog/my-post')
+    const link = screen.getAllByRole('link').find((a) => a.getAttribute('href') === '/blog/my-post')
+    expect(link).toBeDefined()
+  })
+
+  it('renders "See all posts" CTA linking to /blog', () => {
+    render(<FeaturedPosts posts={[makePost()]} />)
+    const cta = screen.getByRole('link', { name: /see all posts/i })
+    expect(cta).toHaveAttribute('href', '/blog')
   })
 
   it('renders 2 posts with lg:grid-cols-2 layout', () => {


### PR DESCRIPTION
Home page caps at 3 newest posts (PR #132); this adds a centered button to the full `/blog` archive.