### PR TITLE
fix(analytics): stop gating $pageview on NEXT_PUBLIC_POSTHOG_KEY

### DIFF
--- a/src/app/PostHogPageView.tsx
+++ b/src/app/PostHogPageView.tsx
@@ -9,7 +9,10 @@ function PageView() {
   const posthog = usePostHog()
 
   useEffect(() => {
-    if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return
+    // Don't gate on NEXT_PUBLIC_POSTHOG_KEY — it isn't reliably set under
+    // next-on-pages builds (see providers.tsx for why the key is hardcoded).
+    // `!posthog` is the real guard: if init didn't happen there's nothing
+    // to capture against.
     if (!pathname || !posthog) return
     posthog.capture('$pageview', { $current_url: window.origin + pathname })
   }, [pathname, posthog])


### PR DESCRIPTION
providers.tsx documents that the env var isn't reliably set under next-on-pages (that's why the key is hardcoded). PostHogPageView still checked it, so the manual `$pageview` capture was being skipped in prod — and `capture_pageview: false` in init meant nothing else was firing them either.

`!posthog` on the next line is the real guard.